### PR TITLE
updates deps to use the branch alias

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     "require" : {
         "php"                      : ">=5.3.3",
         "predis/predis"            : "~0.8",
-        "jms/serializer"           : "dev-master"
+        "jms/serializer"           : "0.12.*"
     },
 
     "require-dev" : {


### PR DESCRIPTION
It's usually better to rely on the branch alias instead of using dev-master.
