### PR TITLE
Fix prefix issue when using PhpRedis

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,11 @@ And then instanciate the correct connection object.
 
 use Bernard\Connection\PhpRedisConnection;
 
-$connection = new PhpRedisConnection(new Redis());
+$redis = new Redis();
+$redis->connect('127.0.0.1', 6379);
+$redis->setOption(Redis::OPT_PREFIX, 'bernard:');
+
+$connection = new PhpRedisConnection($redis);
 ```
 
 #### PredisConnection


### PR DESCRIPTION
Hi Henrik,

Thanks for the last updates, it's very nice :)

I've got a weird error with PhpRedis. When PhpRedis is set up with an Redis::OPT_PREFIX, It does set the prefix to the key and to the timeout value. To set the resolved key in an array seems fixing this issue. @see: https://github.com/nicolasff/phpredis/issues/158

I made a gist with a reproductible example: https://gist.github.com/toin0u/5567583

My configuration:
- PHP 5.4.13
- Redis extention 2.2.2
- Redis 2.6.12
- Mac OS X 10.8.3

This PR "fixes" this problem. What do you think ?
