### PR TITLE
Rename QueueFactory to broker as it is the intermediary between the Producer and Queue

### DIFF
--- a/example/bootstrap.php
+++ b/example/bootstrap.php
@@ -4,7 +4,7 @@ use Predis\Client;
 use Bernard\Connection\PredisConnection;
 use Bernard\Serializer\SymfonySerializer;
 use Bernard\Symfony\EnvelopeNormalizer;
-use Bernard\QueueFactory\PersistentFactory;
+use Bernard\Broker\PersistentBroker;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
 
@@ -18,4 +18,4 @@ $serializer = new SymfonySerializer(new Serializer(array(new EnvelopeNormalizer)
 $connection = new PredisConnection(new Client(null, array(
     'prefix' => 'bernard:',
 )));
-$queues = new PersistentFactory($connection, $serializer);
+$broker = new PersistentBroker($connection, $serializer);

--- a/example/consumer.php
+++ b/example/consumer.php
@@ -10,6 +10,6 @@ $services = new ObjectResolver;
 $services->register('EchoTime', new EchoTimeService);
 
 $consumer = new Consumer($services);
-$consumer->consume($queues->create('echo-time'), $queues->create('failed'), array(
+$consumer->consume($broker->create('echo-time'), $broker->create('failed'), array(
     'max_retries' => 5,
 ));

--- a/example/in_memory.php
+++ b/example/in_memory.php
@@ -8,12 +8,12 @@ use Bernard\Consumer;
 use Bernard\Message\DefaultMessage;
 use Bernard\Producer;
 use Bernard\ServiceResolver\ObjectResolver;
-use Bernard\QueueFactory\InMemoryFactory;
+use Bernard\Broker\InMemoryBroker;
 
 require __DIR__ . '/../vendor/autoload.php';
 require 'EchoTimeService.php';
 
-$queues = new InMemoryFactory;
+$queues = new InMemoryBroker;
 $producer = new Producer($queues);
 
 for ($i = 0; $i < 20;$i++) {

--- a/example/producer.php
+++ b/example/producer.php
@@ -5,7 +5,7 @@ require __DIR__ . '/bootstrap.php';
 use Bernard\Message\DefaultMessage;
 use Bernard\Producer;
 
-$producer = new Producer($queues);
+$producer = new Producer($broker);
 
 while (true) {
     $producer->produce(new DefaultMessage('EchoTime', array(

--- a/src/Bernard/Broker.php
+++ b/src/Bernard/Broker.php
@@ -8,7 +8,7 @@ namespace Bernard;
  *
  * @package Bernard
  */
-interface QueueFactory extends \Countable
+interface Broker extends \Countable
 {
     /**
      * @param  string              $queueName

--- a/src/Bernard/Broker/InMemoryBroker.php
+++ b/src/Bernard/Broker/InMemoryBroker.php
@@ -1,22 +1,23 @@
 <?php
 
-namespace Bernard\QueueFactory;
+namespace Bernard\Broker;
 
 use Bernard\Queue\InMemoryQueue;
 
 /**
- * This is an in memory queue factory. It creates SplQueue objects for the
- * queue. This also means it is not possible to introspect with Juno
+ * This is an in memory broker. It creates SplQueue objects for the
+ * queue. This also means it is not possible to introspect unless it is done
+ * in the same request
  *
  * @package Bernard
  */
-class InMemoryFactory implements \Bernard\QueueFactory
+class InMemoryBroker implements \Bernard\Broker
 {
     protected $queues;
 
     /**
-     * @param  string               $queueName
-     * @return InMemoryQueueFactory
+     * @param  string        $queueName
+     * @return InMemoryQueue
      */
     public function create($queueName)
     {

--- a/src/Bernard/Broker/PersistentBroker.php
+++ b/src/Bernard/Broker/PersistentBroker.php
@@ -1,20 +1,17 @@
 <?php
 
-namespace Bernard\QueueFactory;
+namespace Bernard\Broker;
 
 use Bernard\Connection;
 use Bernard\Queue\PersistentQueue;
 use Bernard\Serializer;
 
 /**
- * Knows how to create queues and retrieve them from the used connection.
- * Every queue it creates is saved locally.
- *
  * @package Bernard
  */
-class PersistentFactory implements \Bernard\QueueFactory
+class PersistentBroker implements \Bernard\Broker
 {
-    protected $queues;
+    protected $queues = array();
     protected $connection;
     protected $serializer;
 
@@ -22,11 +19,8 @@ class PersistentFactory implements \Bernard\QueueFactory
      * @param Connection          $connection
      * @param SerializerInterface $serializer
      */
-    public function __construct(
-        Connection $connection,
-        Serializer $serializer
-    ) {
-        $this->queues     = array();
+    public function __construct(Connection $connection, Serializer $serializer)
+    {
         $this->connection = $connection;
         $this->serializer = $serializer;
     }

--- a/src/Bernard/Producer.php
+++ b/src/Bernard/Producer.php
@@ -2,23 +2,23 @@
 
 namespace Bernard;
 
+use Bernard\Broker;
 use Bernard\Message;
 use Bernard\Message\Envelope;
-use Bernard\QueueFactory;
 
 /**
  * @package Bernard
  */
 class Producer
 {
-    protected $factory;
+    protected $broker;
 
     /**
-     * @param QueueFactory $factory
+     * @param Broker $broker
      */
-    public function __construct(QueueFactory $factory)
+    public function __construct(Broker $broker)
     {
-        $this->factory = $factory;
+        $this->broker = $broker;
     }
 
     /**
@@ -26,7 +26,7 @@ class Producer
      */
     public function produce(Message $message)
     {
-        $queue = $this->factory->create($message->getQueue());
+        $queue = $this->broker->create($message->getQueue());
         $queue->enqueue(new Envelope($message));
     }
 }

--- a/src/Bernard/Symfony/Command/ConsumeCommand.php
+++ b/src/Bernard/Symfony/Command/ConsumeCommand.php
@@ -3,7 +3,7 @@
 namespace Bernard\Symfony\Command;
 
 use Bernard\Consumer;
-use Bernard\QueueFactory;
+use Bernard\Broker;
 use Bernard\ServiceResolver;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -16,16 +16,16 @@ use Symfony\Component\Console\Output\OutputInterface;
 class ConsumeCommand extends \Symfony\Component\Console\Command\Command
 {
     protected $services;
-    protected $queues;
+    protected $broker;
 
     /**
-     * @param ServiceResolver       $services
-     * @param QueueFactoryInterface $queues
+     * @param ServiceResolver $services
+     * @param Broker          $broker
      */
-    public function __construct(ServiceResolver $services, QueueFactory $queues)
+    public function __construct(ServiceResolver $services, Broker $broker)
     {
         $this->services = $services;
-        $this->queues = $queues;
+        $this->broker = $broker;
 
         parent::__construct();
     }
@@ -48,9 +48,9 @@ class ConsumeCommand extends \Symfony\Component\Console\Command\Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $queue = $this->queues->create($input->getArgument('queue'));
+        $queue = $this->broker->create($input->getArgument('queue'));
 
-        $this->getConsumer()->consume($queue, $this->queues->create('failed'), $input->getOptions());
+        $this->getConsumer()->consume($queue, $this->broker->create('failed'), $input->getOptions());
     }
 
     /**

--- a/tests/Bernard/Tests/Broker/InMemoryBrokerTest.php
+++ b/tests/Bernard/Tests/Broker/InMemoryBrokerTest.php
@@ -1,19 +1,19 @@
 <?php
 
-namespace Bernard\Tests;
+namespace Bernard\Tests\Broker;
 
-use Bernard\QueueFactory\InMemoryFactory;
+use Bernard\Broker\InMemoryBroker;
 
-class InMemoryFactoryTest extends \PHPUnit_Framework_TestCase
+class InMemoryBrokerTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->factory = new InMemoryFactory();
+        $this->factory = new InMemoryBroker();
     }
 
-    public function testImplementsQueueFactory()
+    public function testImplementsBroker()
     {
-        $this->assertInstanceOf('Bernard\QueueFactory', $this->factory);
+        $this->assertInstanceOf('Bernard\Broker', $this->factory);
     }
 
     public function testRemoveClosesQueue()

--- a/tests/Bernard/Tests/Broker/PersistentBrokerTest.php
+++ b/tests/Bernard/Tests/Broker/PersistentBrokerTest.php
@@ -1,22 +1,22 @@
 <?php
 
-namespace Bernard\Tests\QueueFactory;
+namespace Bernard\Tests\Broker;
 
-use Bernard\QueueFactory\PersistentFactory;
+use Bernard\Broker\PersistentBroker;
 
-class PersistentFactoryTest extends \PHPUnit_Framework_TestCase
+class PersistentBrokerTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
         $this->connection = $this->getMockBuilder('Bernard\Connection')
             ->disableOriginalConstructor()->getMock();
 
-        $this->factory = new PersistentFactory($this->connection, $this->getMock('Bernard\Serializer'));
+        $this->factory = new PersistentBroker($this->connection, $this->getMock('Bernard\Serializer'));
     }
 
-    public function testImplementsQueueFactory()
+    public function testImplementsBroker()
     {
-        $this->assertInstanceOf('Bernard\QueueFactory', $this->factory);
+        $this->assertInstanceOf('Bernard\Broker', $this->factory);
     }
 
     public function testItSavesQueueObjects()

--- a/tests/Bernard/Tests/ProducerTest.php
+++ b/tests/Bernard/Tests/ProducerTest.php
@@ -17,7 +17,7 @@ class ProducerTest extends \PHPUnit_Framework_TestCase
         $queue = $this->getMock('Bernard\Queue');
         $queue->expects($this->once())->method('enqueue')->with($this->equalTo($envelope));
 
-        $factory = $this->getMock('Bernard\QueueFactory');
+        $factory = $this->getMock('Bernard\Broker');
         $factory->expects($this->once())->method('create')->with($this->equalTo('my-queue'))
             ->will($this->returnValue($queue));
 

--- a/tests/Bernard/Tests/Symfony/Command/ConsumeCommandTest.php
+++ b/tests/Bernard/Tests/Symfony/Command/ConsumeCommandTest.php
@@ -9,7 +9,7 @@ class ConsumeCommandTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->queues = $this->getMock('Bernard\QueueFactory');
+        $this->queues = $this->getMock('Bernard\Broker');
         $this->services = $this->getMock('Bernard\ServiceResolver');
     }
 


### PR DESCRIPTION
Related to #35.

The name QueueFactory is misleading but also correct. But in the Producer - Consumer pattern this is called a Broker which is a 3rd party facilitating the sending from Producer to the Consumer.
