### PR TITLE
Refactor Symfony Serialization

### DIFF
--- a/doc/serializers.rst
+++ b/doc/serializers.rst
@@ -13,6 +13,12 @@ Symfony Serializer Component
 It is important that the serializer uses ``Bernard\Symfony\EnvelopeNormalizer`` and the ``JsonEncoder`` to being able
 to serialize and deserialize messages.
 
+.. warning::
+
+    If you are using ``Bernard\Message\DefaultMessage`` you MUST also register ``Bernard\Symfony\DefaultMessageNormalizer``
+    for proper serialization / deserialization of message. This is strongly encouraged as it is the fallback when message
+    classed cannot be found.
+
 .. configuration-block::
 
     .. code-block:: json

--- a/example/bootstrap.php
+++ b/example/bootstrap.php
@@ -4,6 +4,7 @@ use Predis\Client;
 use Bernard\Driver\PredisDriver;
 use Bernard\Serializer\SymfonySerializer;
 use Bernard\Symfony\EnvelopeNormalizer;
+use Bernard\Symfony\DefaultMessageNormalizer;
 use Bernard\QueueFactory\PersistentFactory;
 use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
@@ -13,7 +14,10 @@ require __DIR__ . '/../vendor/autoload.php';
 ini_set('display_erros', 1);
 error_reporting(E_ALL);
 
-$serializer = new SymfonySerializer(new Serializer(array(new EnvelopeNormalizer), array(new JsonEncoder)));
+$normalizers = array(new EnvelopeNormalizer, new DefaultMessageNormalizer);
+$serializer = new SymfonySerializer(
+    new Serializer($normalizers, array(new JsonEncoder))
+);
 
 $connection = new PredisDriver(new Client(null, array(
     'prefix' => 'bernard:',

--- a/src/Bernard/JMSSerializer/EnvelopeHandler.php
+++ b/src/Bernard/JMSSerializer/EnvelopeHandler.php
@@ -110,11 +110,7 @@ class EnvelopeHandler implements \JMS\Serializer\Handler\SubscribingHandlerInter
      */
     public function serializeDefaultMessage(AbstractVisitor $visitor, DefaultMessage $message, $type, Context $context)
     {
-        $data = array(
-            'name' => $message->getName(),
-        );
-
-        return array_merge($data, get_object_vars($message));
+        return array('name' => $message->getName()) + get_object_vars($message);
     }
 
     /**

--- a/src/Bernard/Symfony/DefaultMessageNormalizer.php
+++ b/src/Bernard/Symfony/DefaultMessageNormalizer.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Bernard\Symfony;
+
+use Bernard\Message\DefaultMessage;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+
+/**
+ * @package Bernard
+ */
+class DefaultMessageNormalizer implements NormalizerInterface, DenormalizerInterface
+{
+    /**
+     * {@inheritDoc}
+     */
+    public function normalize($object, $format = null, array $context = array())
+    {
+        return array('name' => $object->getName()) + get_object_vars($object);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function denormalize($data, $class, $format = null, array $context = array())
+    {
+        return new DefaultMessage($data['name'], $data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $this->supports($data);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supportsDenormalization($data, $type, $format = null)
+    {
+        return $this->supports($type);
+    }
+
+    /**
+     * @param string|object $class
+     * @return boolean
+     */
+    protected function supports($class)
+    {
+        if (is_object($class)) {
+            $class = get_class($class);
+        }
+
+        return $class == 'Bernard\Message\DefaultMessage';
+    }
+}

--- a/tests/Bernard/Tests/Fixtures/SendNewsletterMessage.php
+++ b/tests/Bernard/Tests/Fixtures/SendNewsletterMessage.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace SerializerApplication;
+
+use Bernard\Message\AbstractMessage;
+use JMS\Serializer\Annotation as JMSSerializer;
+use Symfony\Component\Serializer\Normalizer\DenormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
+use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
+use Symfony\Component\Serializer\Normalizer\DenormalizableInterface;
+
+/**
+ * This is a Custom implementation of a Message.
+ */
+class SendNewsletterMessage extends AbstractMessage implements NormalizableInterface, DenormalizableInterface
+{
+    /**
+     * @JMSSerializer\Type("integer")
+     * @JMSSerializer\SerializedName("newsletterId")
+     */
+    public $newsletterId = 10;
+
+    public function normalize(NormalizerInterface $normalizer, $format = null, array $context = array())
+    {
+        return get_object_vars($this);
+    }
+
+    public function denormalize(DenormalizerInterface $denormalizer, $data, $format = null, array $context = array())
+    {
+        $this->newsletterId = $data['newsletterId'];
+    }
+}

--- a/tests/Bernard/Tests/Serializer/AbstractSerializerTest.php
+++ b/tests/Bernard/Tests/Serializer/AbstractSerializerTest.php
@@ -5,6 +5,8 @@ namespace Bernard\Tests\Serializer;
 use Bernard\Message\Envelope;
 use Bernard\Message\DefaultMessage;
 
+require __DIR__ . '/../Fixtures/SendNewsletterMessage.php';
+
 abstract class AbstractSerializerTest extends \PHPUnit_Framework_TestCase
 {
     abstract public function createSerializer();
@@ -35,28 +37,29 @@ abstract class AbstractSerializerTest extends \PHPUnit_Framework_TestCase
 
     public function testItSerializesACustomImplementedMessage()
     {
-        $json = '{"args":{},"class":"SymfonySerializerApplication:SendNewsletterMessage","timestamp":' . time() . ',"retries":0}';
-        $this->assertEquals($json, $this->serializer->serialize(new Envelope(new \SymfonySerializerApplication\SendNewsletterMessage())));
+        $json = '{"args":{"newsletterId":10},"class":"SerializerApplication:SendNewsletterMessage","timestamp":' . time() . ',"retries":0}';
+        $this->assertEquals($json, $this->serializer->serialize(new Envelope(new \SerializerApplication\SendNewsletterMessage())));
     }
 
     public function testItDeserializesACustomImplementedMessage()
     {
-        $json = '{"args":{},"class":"SymfonySerializerApplication:SendNewsletterMessage","timestamp":' . time() . ',"retries":0}';
+        $json = '{"args":{"newsletterId":10},"class":"SerializerApplication:SendNewsletterMessage","timestamp":' . time() . ',"retries":0}';
         $envelope = $this->serializer->deserialize($json);
 
-        $this->assertInstanceOf('SymfonySerializerApplication\SendNewsletterMessage', $envelope->getMessage());
+        $this->assertInstanceOf('SerializerApplication\SendNewsletterMessage', $envelope->getMessage());
     }
 
     public function testItDeserializesAnUnknownClass()
     {
         $time = time();
 
-        $json = '{"args":{},"class":"UnknownNamespace:UnknownMessage","timestamp":' . $time . ',"retries":0}';
+        $json = '{"args":{"meaningOfLife":42},"class":"UnknownNamespace:UnknownMessage","timestamp":' . $time . ',"retries":0}';
         $envelope = $this->serializer->deserialize($json);
 
         $this->assertInstanceOf('Bernard\Message\DefaultMessage', $envelope->getMessage());
         $this->assertEquals('UnknownNamespace\\UnknownMessage', $envelope->getClass());
         $this->assertEquals('UnknownMessage', $envelope->getMessage()->getName());
+        $this->assertEquals(42, $envelope->getMessage()->meaningOfLife);
     }
 
     public function testItDeserializesDefaultMessage()
@@ -72,6 +75,3 @@ abstract class AbstractSerializerTest extends \PHPUnit_Framework_TestCase
         return new Envelope(new DefaultMessage($name, $properties));
     }
 }
-
-namespace SymfonySerializerApplication;
-class SendNewsletterMessage extends \Bernard\Message\AbstractMessage {}

--- a/tests/Bernard/Tests/Serializer/JMSSerializerTest.php
+++ b/tests/Bernard/Tests/Serializer/JMSSerializerTest.php
@@ -2,15 +2,17 @@
 
 namespace Bernard\Tests\Serializer;
 
-use Bernard\Serializer\JMSSerializer;
 use Bernard\JMSSerializer\EnvelopeHandler;
+use Bernard\Serializer\JMSSerializer;
 use JMS\Serializer\SerializerBuilder;
+use Doctrine\Common\Annotations\AnnotationRegistry;
 
 class JMSSerializerTest extends AbstractSerializerTest
 {
     public function createSerializer()
     {
-        $class = new \ReflectionClass('Bernard\Serializer');
+        AnnotationRegistry::registerLoader(current(spl_autoload_functions()));
+
         $builder = new SerializerBuilder();
         $builder->configureHandlers(function ($registry) {
             $registry->registerSubscribingHandler(new EnvelopeHandler);

--- a/tests/Bernard/Tests/Serializer/SymfonySerializerTest.php
+++ b/tests/Bernard/Tests/Serializer/SymfonySerializerTest.php
@@ -3,14 +3,18 @@
 namespace Bernard\Tests\Serializer;
 
 use Bernard\Serializer\SymfonySerializer;
+use Bernard\Symfony\DefaultMessageNormalizer;
 use Bernard\Symfony\EnvelopeNormalizer;
-use Symfony\Component\Serializer\Serializer;
 use Symfony\Component\Serializer\Encoder\JsonEncoder;
+use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
+use Symfony\Component\Serializer\Serializer;
 
 class SymfonySerializerTest extends AbstractSerializerTest
 {
     public function createSerializer()
     {
-        return new SymfonySerializer(new Serializer(array(new EnvelopeNormalizer), array(new JsonEncoder)));
+        $normalizers = array(new EnvelopeNormalizer, new DefaultMessageNormalizer, new CustomNormalizer);
+
+        return new SymfonySerializer(new Serializer($normalizers, array(new JsonEncoder)));
     }
 }


### PR DESCRIPTION
To Support complex message graph the EnvelopeNormalizer must ask the
serializer to denormaliza as there can be other denormalizers. To
accomplish this a DefaultMessageNormalizer was created.

Also to have a more complete example of custom deserialization a Fixture
directory with a SendNewsletterMessage is added with custom metadata for
JMS Serializer (Annotations) and Symfony Serializer Component (CustomNormalizer).
