### PR TITLE
Add log for each message produced

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
         "jms/serializer"               : "~0.12",
         "pimple/pimple"                : "~1.0",
         "predis/predis"                : "~0.8",
+        "psr/log"                      : "~1.0",
         "symfony/console"              : "~2.0",
         "symfony/dependency-injection" : "~2.0",
         "symfony/serializer"           : "~2.2"

--- a/src/Bernard/Producer.php
+++ b/src/Bernard/Producer.php
@@ -5,6 +5,7 @@ namespace Bernard;
 use Bernard\Message;
 use Bernard\Message\Envelope;
 use Bernard\QueueFactory;
+use Psr\Log\LoggerInterface;
 
 /**
  * @package Bernard
@@ -12,13 +13,16 @@ use Bernard\QueueFactory;
 class Producer
 {
     protected $factory;
+    protected $logger;
 
     /**
      * @param QueueFactory $factory
+     * @param LoggerInterface $logger
      */
-    public function __construct(QueueFactory $factory)
+    public function __construct(QueueFactory $factory, LoggerInterface $logger = null)
     {
         $this->factory = $factory;
+        $this->logger = $logger;
     }
 
     /**
@@ -28,5 +32,13 @@ class Producer
     {
         $queue = $this->factory->create($message->getQueue());
         $queue->enqueue(new Envelope($message));
+
+        if (null !== $this->logger) {
+            $this->logger->info('Enqueued message {name} to {queue}', array(
+                'name'    => $message->getName(),
+                'queue'   => $message->getQueue(),
+                'message' => $message,
+            ));
+        }
     }
 }

--- a/tests/Bernard/Tests/ProducerTest.php
+++ b/tests/Bernard/Tests/ProducerTest.php
@@ -24,4 +24,26 @@ class ProducerTest extends \PHPUnit_Framework_TestCase
         $publisher = new Producer($factory);
         $publisher->produce($message);
     }
+
+    public function testItLogMessages()
+    {
+        $message = $this->getMock('Bernard\Message');
+        $message->expects($this->exactly(2))->method('getQueue')->will($this->returnValue('my-queue'));
+        $message->expects($this->once())->method('getName')->will($this->returnValue('MyMessage'));
+
+        $queue = $this->getMock('Bernard\Queue');
+
+        $logger = $this->getMock('Psr\Log\LoggerInterface');
+        $logger->expects($this->once())->method('info')->with(
+            $this->equalTo('Enqueued message {name} to {queue}'),
+            $this->equalTo(array('name' => 'MyMessage', 'queue' => 'my-queue', 'message' => $message))
+        );
+
+        $factory = $this->getMock('Bernard\QueueFactory');
+        $factory->expects($this->once())->method('create')->with($this->equalTo('my-queue'))
+            ->will($this->returnValue($queue));
+
+        $publisher = new Producer($factory, $logger);
+        $publisher->produce($message);
+    }
 }


### PR DESCRIPTION
The logger will write an entry for each new message with the following text:
"Enqueued message MyMessage to my-queue"

This is useful for debugging and is required to create a DataCollector for the Symfony profiler.
