### PR TITLE
WIP - Add event dispatcher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
         "pimple/pimple"                : "~1.0",
         "predis/predis"                : "~0.8",
         "symfony/console"              : "~2.0",
+        "symfony/event-dispatcher"     : "~2.0",
         "symfony/dependency-injection" : "~2.0",
         "symfony/serializer"           : "~2.2"
     },

--- a/src/Bernard/BernardEvents.php
+++ b/src/Bernard/BernardEvents.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Bernard;
+
+use Symfony\Component\EventDispatcher\Event as SymfonyEvent;
+
+final class BernardEvents extends SymfonyEvent
+{
+    /**
+     * The PRODUCE event occurs before enqueuing a message.
+     */
+    const PRODUCE = 'bernard.produce';
+
+    /**
+     * The CONSUME event occurs when a message is dequeued by the consumer.
+     */
+    const CONSUME = 'bernard.consume';
+
+    /**
+     * The EXCEPTION event occurs if the message processing fails.
+     */
+    const EXCEPTION = 'bernard.exception';
+}

--- a/src/Bernard/EventDispatcher/ExceptionEvent.php
+++ b/src/Bernard/EventDispatcher/ExceptionEvent.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Bernard\EventDispatcher;
+
+use Bernard\Message;
+
+/**
+ * Event for exceptions
+ *
+ * @package Bernard
+ */
+class ExceptionEvent extends MessageEvent
+{
+    protected $exception;
+
+    /**
+     * @param  Message   $messsage
+     * @param  Exception $exception
+     */
+    public function __construct(Message $message, \Exception $exception)
+    {
+        parent::__construct($message);
+
+        $this->exception = $exception;
+    }
+
+    /**
+     * return \Exception
+     */
+    public function getException()
+    {
+        return $this->exception;
+    }
+}

--- a/src/Bernard/EventDispatcher/MessageEvent.php
+++ b/src/Bernard/EventDispatcher/MessageEvent.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Bernard\EventDispatcher;
+
+use Bernard\Message;
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * Event related to a message.
+ *
+ * @package Bernard
+ */
+class MessageEvent extends Event
+{
+    private $message;
+
+    public function __construct(Message $message)
+    {
+        $this->message = $message;
+    }
+
+    public function getMessage()
+    {
+        return $this->message;
+    }
+}

--- a/src/Bernard/Producer.php
+++ b/src/Bernard/Producer.php
@@ -5,6 +5,8 @@ namespace Bernard;
 use Bernard\Message;
 use Bernard\Message\Envelope;
 use Bernard\QueueFactory;
+use Bernard\EventDispatcher\MessageEvent;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 /**
  * @package Bernard
@@ -12,6 +14,7 @@ use Bernard\QueueFactory;
 class Producer
 {
     protected $factory;
+    protected $dispatcher;
 
     /**
      * @param QueueFactory $factory
@@ -22,10 +25,24 @@ class Producer
     }
 
     /**
+     * Set the event dispatcher to dispatch PRODUCE event.
+     *
+     * @param  EventDispatcherInterface $dispatcher
+     */
+    public function setEventDispatcher(EventDispatcherInterface $dispatcher)
+    {
+        $this->dispatcher = $dispatcher;
+    }
+
+    /**
      * {@inheritDoc}
      */
     public function produce(Message $message)
     {
+        if (null !== $this->dispatcher) {
+            $this->dispatcher->dispatch(BernardEvents::PRODUCE, new MessageEvent($message));
+        }
+
         $queue = $this->factory->create($message->getQueue());
         $queue->enqueue(new Envelope($message));
     }


### PR DESCRIPTION
Alternative to #40

This is a Work in progress. I want to validate before going farther.

TODO: 
- [x] Create a BernardEvents class for event names
- [x] Dispatch event `PRODUCE` before enqueuing a message in the `Producer`
- [x] Dispatch event `CONSUME` after dequeuing a message in the `Consumer`
- [x] Dispatch event `EXCEPTION` for errors in the `Consumer`
- [ ] Write unit tests
- [ ] Doc
