### PR TITLE
Use Envelope everywhere internally

### DIFF
--- a/src/Bernard/Message/Envelope.php
+++ b/src/Bernard/Message/Envelope.php
@@ -10,7 +10,7 @@ use Bernard\Message;
  *
  * @package Bernard
  */
-final class Envelope
+class Envelope
 {
     protected $message;
     protected $class;

--- a/src/Bernard/Pimple/PimpleAwareResolver.php
+++ b/src/Bernard/Pimple/PimpleAwareResolver.php
@@ -3,7 +3,7 @@
 namespace Bernard\Pimple;
 
 use Pimple;
-use Bernard\Message;
+use Bernard\Message\Envelope;
 use Bernard\ServiceResolver\Invocator;
 
 /**
@@ -33,12 +33,12 @@ class PimpleAwareResolver implements \Bernard\ServiceResolver
     /**
      * {@inheritDoc}
      */
-    public function resolve(Message $message)
+    public function resolve(Envelope $envelope)
     {
-        if (!isset($this->services[$message->getName()])) {
-            throw new \InvalidArgumentException('No service registered for message "' . $message->getName() . '".');
+        if (!isset($this->services[$envelope->getName()])) {
+            throw new \InvalidArgumentException('No service registered for envelope "' . $envelope->getName() . '".');
         }
 
-        return new Invocator($this->container[$this->services[$message->getName()]], $message);
+        return new Invocator($this->container[$this->services[$envelope->getName()]], $envelope);
     }
 }

--- a/src/Bernard/ServiceResolver.php
+++ b/src/Bernard/ServiceResolver.php
@@ -2,7 +2,7 @@
 
 namespace Bernard;
 
-use Bernard\Message;
+use Bernard\Message\Envelope;
 use Bernard\ServiceResolver\Invocator;
 
 /**
@@ -17,8 +17,8 @@ interface ServiceResolver
     public function register($name, $service);
 
     /**
-     * @param  Message   $message
+     * @param  Envelope   $envelope
      * @return Invocator
      */
-    public function resolve(Message $message);
+    public function resolve(Envelope $envelope);
 }

--- a/src/Bernard/ServiceResolver/Invocator.php
+++ b/src/Bernard/ServiceResolver/Invocator.php
@@ -2,7 +2,7 @@
 
 namespace Bernard\ServiceResolver;
 
-use Bernard\Message;
+use Bernard\Message\Envelope;
 
 /**
  * @package Bernard
@@ -10,15 +10,15 @@ use Bernard\Message;
 class Invocator
 {
     protected $object;
-    protected $message;
+    protected $envelope;
 
     /**
      * @param object $object
      */
-    public function __construct($object, Message $message)
+    public function __construct($object, Envelope $envelope)
     {
         $this->object  = $object;
-        $this->message = $message;
+        $this->envelope = $envelope;
     }
 
     /**
@@ -26,7 +26,7 @@ class Invocator
      */
     public function getMethodName()
     {
-        return 'on' . ucfirst($this->message->getName());
+        return 'on' . ucfirst($this->envelope->getName());
     }
 
     /**
@@ -41,7 +41,7 @@ class Invocator
     public function invoke()
     {
         $method = new \ReflectionMethod($this->object, $this->getMethodName());
-        $method->invoke($this->object, $this->message);
+        $method->invoke($this->object, $this->envelope->getMessage());
     }
 
     /**

--- a/src/Bernard/ServiceResolver/ObjectResolver.php
+++ b/src/Bernard/ServiceResolver/ObjectResolver.php
@@ -2,7 +2,7 @@
 
 namespace Bernard\ServiceResolver;
 
-use Bernard\Message;
+use Bernard\Message\Envelope;
 
 /**
  * @package Bernard
@@ -26,12 +26,14 @@ class ObjectResolver implements \Bernard\ServiceResolver
     /**
      * {@inheritDoc}
      */
-    public function resolve(Message $message)
+    public function resolve(Envelope $envelope)
     {
-        if (isset($this->services[$message->getName()])) {
-            return new Invocator($this->services[$message->getName()], $message);
+        $name = $envelope->getName();
+
+        if (isset($this->services[$name])) {
+            return new Invocator($this->services[$name], $envelope);
         }
 
-        throw new \InvalidArgumentException('No service registered for message "' . $message->getName() . '".');
+        throw new \InvalidArgumentException('No service registered for message "' . $name . '".');
     }
 }

--- a/src/Bernard/Spork/ProcessDecoratingResolver.php
+++ b/src/Bernard/Spork/ProcessDecoratingResolver.php
@@ -2,7 +2,7 @@
 
 namespace Bernard\Spork;
 
-use Bernard\Message;
+use Bernard\Message\Envelope;
 use Bernard\ServiceResolver;
 use Spork\ProcessManager;
 
@@ -39,8 +39,8 @@ class ProcessDecoratingResolver implements ServiceResolver
     /**
      * {@inheritDoc}
      */
-    public function resolve(Message $message)
+    public function resolve(Envelope $envelope)
     {
-        return new ProcessInvocator($this->spork, $this->resolver->resolve($message));
+        return new ProcessInvocator($this->spork, $this->resolver->resolve($envelope));
     }
 }

--- a/src/Bernard/Symfony/ContainerAwareResolver.php
+++ b/src/Bernard/Symfony/ContainerAwareResolver.php
@@ -2,7 +2,7 @@
 
 namespace Bernard\Symfony;
 
-use Bernard\Message;
+use Bernard\Message\Envelope;
 use Bernard\ServiceResolver\Invocator;
 use Symfony\Component\DependencyInjection\Container;
 
@@ -33,12 +33,12 @@ class ContainerAwareResolver implements \Bernard\ServiceResolver
     /**
      * {@inheritDoc}
      */
-    public function resolve(Message $message)
+    public function resolve(Envelope $envelope)
     {
-        if (!isset($this->services[$message->getName()])) {
-            throw new \InvalidArgumentException('No service registered for message "' . $message->getName() . '".');
+        if (!isset($this->services[$envelope->getName()])) {
+            throw new \InvalidArgumentException('No service registered for envelope "' . $envelope->getName() . '".');
         }
 
-        return new Invocator($this->container->get($this->services[$message->getName()]), $message);
+        return new Invocator($this->container->get($this->services[$envelope->getName()]), $envelope);
     }
 }

--- a/tests/Bernard/Tests/Pimple/PimpleAwareResolverTest.php
+++ b/tests/Bernard/Tests/Pimple/PimpleAwareResolverTest.php
@@ -1,8 +1,9 @@
 <?php
 
-namespace Bernard\Tests\ServiceResolver;
+namespace Bernard\Tests\Pimple;
 
 use Bernard\ServiceResolver\Invocator;
+use Bernard\Message\Envelope;
 use Bernard\Message\DefaultMessage;
 use Bernard\Pimple\PimpleAwareResolver;
 use Pimple;
@@ -19,13 +20,13 @@ class PimpleAwareResolverTest extends \PHPUnit_Framework_TestCase
     public function testExceptionWhenMessageCannotBeResolved()
     {
         $this->setExpectedException('InvalidArgumentException',
-            'No service registered for message "SendNewsletter".'); 
+            'No service registered for envelope "SendNewsletter".'); 
 
         $resolver = $this->createResolver();
 
         $this->assertEquals(array(), $this->container->keys());
 
-        $resolver->resolve(new DefaultMessage('SendNewsletter'));
+        $resolver->resolve($this->createEnvelope());
     }
 
     public function testResolveToServiceFromContainer()
@@ -36,7 +37,7 @@ class PimpleAwareResolverTest extends \PHPUnit_Framework_TestCase
 
         $resolver->register('SendNewsletter', 'my.service.id');
 
-        $this->assertEquals(new Invocator($service, new DefaultMessage('SendNewsletter')), $resolver->resolve(new DefaultMessage('SendNewsletter')));
+        $this->assertEquals(new Invocator($service, $this->createEnvelope()), $resolver->resolve($this->createEnvelope()));
     }
 
     public function testExceptionWhenServiceDosentExistOnContainer()
@@ -46,7 +47,12 @@ class PimpleAwareResolverTest extends \PHPUnit_Framework_TestCase
 
         $resolver = $this->createResolver();
         $resolver->register('SendNewsletter', 'non_existant_service_id');
-        $resolver->resolve(new DefaultMessage('SendNewsletter'));
+        $resolver->resolve($this->createEnvelope());
+    }
+
+    protected function createEnvelope()
+    {
+        return new Envelope(new DefaultMessage('SendNewsletter'));
     }
 
 }

--- a/tests/Bernard/Tests/ServiceResolver/InvocatorTest.php
+++ b/tests/Bernard/Tests/ServiceResolver/InvocatorTest.php
@@ -9,14 +9,15 @@ class InvocatorTest extends \PHPUnit_Framework_TestCase
 {
     public function testItInvokesServiceObject()
     {
-        $message = new DefaultMessage('SendNewsletter');
+        $envelope = $this->getMockBuilder('Bernard\Message\Envelope')
+            ->disableOriginalConstructor()->getMock();
+        $envelope->expects($this->once())->method('getName')->will($this->returnValue('SendNewsletter'));
+        $envelope->expects($this->once())->method('getMessage')->will($this->returnValue('message'));
 
         $service = $this->getMock('stdClass', array('onSendNewsletter'));
-        $service->expects($this->exactly(2))->method('onSendNewsletter')->with($this->equalTo($message));
+        $service->expects($this->once())->method('onSendNewsletter')->with($this->equalTo('message'));
 
-        $invocator = new Invocator($service, $message);
+        $invocator = new Invocator($service, $envelope);
         $invocator->invoke();
-
-        $invocator();
     }
 }

--- a/tests/Bernard/Tests/ServiceResolver/ObjectResolverTest.php
+++ b/tests/Bernard/Tests/ServiceResolver/ObjectResolverTest.php
@@ -2,6 +2,7 @@
 
 namespace Bernard\Tests\ServiceResolver;
 
+use Bernard\Message\Envelope;
 use Bernard\ServiceResolver\ObjectResolver;
 use Bernard\ServiceResolver\Invocator;
 
@@ -24,26 +25,22 @@ class ObjectResolverTest extends \PHPUnit_Framework_TestCase
 
     public function testItResolvesBasedOnMessageName()
     {
-        $message = $this->getMock('Bernard\Message');
-        $message->expects($this->any())->method('getName')->will($this->returnValue('SendNewsletter'));
-
         $service = new \stdClass;
 
         $resolver = new ObjectResolver;
         $resolver->register('SendNewsletter', $service);
 
-        $this->assertEquals(new Invocator($service, $message), $resolver->resolve($message));
+        $envelope = $this->createEnvelope();
+
+        $this->assertEquals(new Invocator($service, $envelope), $resolver->resolve($envelope));
     }
 
     public function testItThrowsExceptionIfServiceCannotBeFound()
     {
         $this->setExpectedException('InvalidArgumentException');
 
-        $message = $this->getMock('Bernard\Message');
-        $message->expects($this->any())->method('getName')->will($this->returnValue('SendNewsletter'));
-
         $resolver = new ObjectResolver;
-        $resolver->resolve($message);
+        $resolver->resolve($this->createEnvelope());
     }
 
     public function dataProviderNotObjects()
@@ -55,5 +52,13 @@ class ObjectResolverTest extends \PHPUnit_Framework_TestCase
             array('SendNewsletter', 1.02),
             array('SendNewsletter', 12),
         );
+    }
+
+    protected function createEnvelope()
+    {
+        $message = $this->getMock('Bernard\Message');
+        $message->expects($this->any())->method('getName')->will($this->returnValue('SendNewsletter'));
+
+        return new Envelope($message);
     }
 }

--- a/tests/Bernard/Tests/Spork/ProcessDecoratingResolverTest.php
+++ b/tests/Bernard/Tests/Spork/ProcessDecoratingResolverTest.php
@@ -32,13 +32,14 @@ class ProcessDecoratingResolverTest extends \PHPUnit_Framework_TestCase
         $invocator = $this->getMockBuilder('Bernard\ServiceResolver\Invocator')->disableOriginalConstructor()
             ->getMock();
 
-        $message = $this->getMock('Bernard\Message');
+        $envelope = $this->getMockBuilder('Bernard\Message\Envelope')
+            ->disableOriginalConstructor()->getMock();
 
-        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo($message))
+        $this->resolver->expects($this->once())->method('resolve')->with($this->equalTo($envelope))
             ->will($this->returnValue($invocator));
 
         $resolver = new ProcessDecoratingResolver($this->spork, $this->resolver);
 
-        $this->assertEquals(new ProcessInvocator($this->spork, $invocator), $resolver->resolve($message));
+        $this->assertEquals(new ProcessInvocator($this->spork, $invocator), $resolver->resolve($envelope));
     }
 }

--- a/tests/Bernard/Tests/Spork/ProcessInvocatorTest.php
+++ b/tests/Bernard/Tests/Spork/ProcessInvocatorTest.php
@@ -2,6 +2,7 @@
 
 namespace Bernard\Tests\Spork;
 
+use Bernard\Message\Envelope;
 use Bernard\ServiceResolver\Invocator;
 use Bernard\Spork\ProcessInvocator;
 use Spork\ProcessManager;
@@ -42,13 +43,18 @@ class ProcessInvocatorTest extends \PHPUnit_Framework_TestCase
 
         $this->setExpectedException('Bernard\Spork\Exception\ProcessException');
 
-        $message = $this->getMock('Bernard\Message');
-        $message->expects($this->any())->method('getName')->will($this->returnValue('ImportUsers'));
-
-        $invocator = new Invocator(new FailingService(), $message);
+        $invocator = new Invocator(new FailingService(), $this->createEnvelope());
 
         $forking = new ProcessInvocator(new ProcessManager(), $invocator);
         $forking->invoke();
+    }
+
+    protected function createEnvelope()
+    {
+        $message = $this->getMock('Bernard\Message');
+        $message->expects($this->any())->method('getName')->will($this->returnValue('ImportUsers'));
+
+        return new Envelope($message);
     }
 }
 


### PR DESCRIPTION
For the end user all they should see is a Message but internally the system should use an Envelope as it contains more information.
