### PR TITLE
Refactor DoctrineDriver schema to have a seperate queue table.

### DIFF
--- a/src/Bernard/Doctrine/MessagesSchema.php
+++ b/src/Bernard/Doctrine/MessagesSchema.php
@@ -2,7 +2,7 @@
 
 namespace Bernard\Doctrine;
 
-use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Schema\Schema;
 
 /**
  * @package Bernard
@@ -10,14 +10,26 @@ use Doctrine\DBAL\Schema\Table;
 class MessagesSchema
 {
     /**
-     * Returns a Table instance setup to save messages for the queue in the
-     * database.
+     * Creates tables on the current schema given.
      *
-     * @return Table
+     * @param Schema $schema
      */
-    public function createTable()
+    public static function create(Schema $schema)
     {
-        $table = new Table('bernard_messages');
+        static::createQueueTable($schema);
+        static::createMessagesTable($schema);
+    }
+
+    protected static function createQueueTable(Schema $schema)
+    {
+        $table = $schema->createTable('bernard_queues');
+        $table->addColumn('name', 'string');
+        $table->setPrimaryKey(array('name'));
+    }
+
+    protected static function createMessagesTable(Schema $schema)
+    {
+        $table = $schema->createTable('bernard_messages');
         $table->addColumn('id', 'integer', array(
             'autoincrement' => true,
             'unsigned'      => true,
@@ -29,9 +41,6 @@ class MessagesSchema
         $table->addColumn('visible', 'boolean', array('default' => true));
         $table->addColumn('sentAt', 'datetime');
         $table->setPrimaryKey(array('id'));
-        $table->addIndex(array('queue'));
         $table->addIndex(array('queue', 'sentAt', 'visible'));
-
-        return $table;
     }
 }

--- a/src/Bernard/Driver/DoctrineDriver.php
+++ b/src/Bernard/Driver/DoctrineDriver.php
@@ -26,7 +26,7 @@ class DoctrineDriver implements \Bernard\Driver
      */
     public function listQueues()
     {
-        $statement = $this->connection->prepare('SELECT queue FROM bernard_messages GROUP BY queue');
+        $statement = $this->connection->prepare('SELECT name FROM bernard_queues');
         $statement->execute();
 
         return $statement->fetchAll(\PDO::FETCH_COLUMN);
@@ -37,7 +37,9 @@ class DoctrineDriver implements \Bernard\Driver
      */
     public function createQueue($queueName)
     {
-        // noop
+        try {
+            $this->connection->insert('bernard_queues', array('name' => $queueName));
+        } catch (\Exception $e) {}
     }
 
     /**
@@ -62,6 +64,7 @@ class DoctrineDriver implements \Bernard\Driver
             'sentAt'  => new \DateTime(),
         );
 
+        $this->createQueue($queueName);
         $this->connection->insert('bernard_messages', $data, $types);
     }
 
@@ -129,6 +132,7 @@ class DoctrineDriver implements \Bernard\Driver
     public function removeQueue($queueName)
     {
         $this->connection->delete('bernard_messages', array('queue' => $queueName));
+        $this->connection->delete('bernard_queues', array('name' => $queueName));
     }
 
     /**


### PR DESCRIPTION
When using the Doctrine driver together with Juno it would remove the queue from the list when empty, this fixes that. And makes it more inline with Kombu.
