### PR TITLE
add __toString to queue interface

### DIFF
--- a/src/Bernard/Queue.php
+++ b/src/Bernard/Queue.php
@@ -37,4 +37,11 @@ interface Queue extends \Countable
      * @param Envelope $envelope
      */
     public function acknowledge(Envelope $envelope);
+
+    /**
+     * Return the queue textual representation, normally this will be name (not the internal key)
+     *
+     * @return string
+     */
+    public function __toString();
 }

--- a/src/Bernard/Queue/AbstractQueue.php
+++ b/src/Bernard/Queue/AbstractQueue.php
@@ -49,4 +49,12 @@ abstract class AbstractQueue implements \Bernard\Queue
             throw new InvalidOperationException(sprintf('Queue "%s" is closed.', $this->name));
         }
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __toString()
+    {
+        return (string) $this->name;
+    }
 }

--- a/tests/Bernard/Tests/Queue/AbstractQueueTest.php
+++ b/tests/Bernard/Tests/Queue/AbstractQueueTest.php
@@ -19,6 +19,14 @@ abstract class AbstractQueueTest extends \PHPUnit_Framework_TestCase
         call_user_func_array(array($queue, $method), $arguments);
     }
 
+    public function testNameAsToString()
+    {
+        $queue = $this->createQueue('long-name');
+
+        $this->assertEquals('long-name', (string) $queue);
+        $this->assertEquals('long-name', $queue);
+    }
+
     public function dataClosedMethods()
     {
         return array(


### PR DESCRIPTION
Most of the queues have names that identify them in their driver or in the factory. So in order to have their name in log messages and in retry messages (where they originate from).
