### PR TITLE
Added --queue option

### DIFF
--- a/src/Bernard/Command/ProduceCommand.php
+++ b/src/Bernard/Command/ProduceCommand.php
@@ -5,6 +5,7 @@ namespace Bernard\Command;
 use Bernard\Producer;
 use Bernard\Message\DefaultMessage;
 use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -31,6 +32,7 @@ class ProduceCommand extends \Symfony\Component\Console\Command\Command
     public function configure()
     {
         $this
+            ->addOption('queue', null, InputOption::VALUE_OPTIONAL, 'Name of a queue to add this job to. By default the queue is guessed from the message name.', null)
             ->addArgument('name', InputArgument::REQUIRED, 'Name for the message eg. "ImportUsers".')
             ->addArgument('message', InputArgument::OPTIONAL, 'JSON encoded string that is used for message properties.')
         ;
@@ -43,11 +45,12 @@ class ProduceCommand extends \Symfony\Component\Console\Command\Command
     {
         $name    = $input->getArgument('name');
         $message = json_decode($input->getArgument('message'), true) ?: array();
+        $queue   = $input->getOption('queue');
 
         if (json_last_error()) {
             throw new \RuntimeException('Could not decode invalid JSON [' . json_last_error() . ']');
         }
 
-        $this->producer->produce(new DefaultMessage($name, $message));
+        $this->producer->produce(new DefaultMessage($name, $message), $queue);
     }
 }


### PR DESCRIPTION
Added `--queue` as option.
This will allow you to add jobs to named queues rather than generated queues.
