### PR TITLE
Fixes exception name

### DIFF
--- a/tests/Bernard/Tests/Driver/MongoDBDriverFunctionalTest.php
+++ b/tests/Bernard/Tests/Driver/MongoDBDriverFunctionalTest.php
@@ -5,7 +5,7 @@ namespace Bernard\Tests\Driver;
 use Bernard\Driver\MongoDBDriver;
 use MongoClient;
 use MongoCollection;
-use MongoException;
+use MongoConnectionException;
 
 /**
  * @coversDefaultClass Bernard\Driver\MongoDBDriver


### PR DESCRIPTION
Fixes a wrong exception name which made it impossible to skip mongo tests in case of error.