### PR TITLE
Allow receipts to be objects

### DIFF
--- a/src/Bernard/Driver/PheanstalkDriver.php
+++ b/src/Bernard/Driver/PheanstalkDriver.php
@@ -59,7 +59,7 @@ class PheanstalkDriver implements \Bernard\Driver
     public function popMessage($queueName, $interval = 5)
     {
         if ($job = $this->pheanstalk->reserveFromTube($queueName, $interval)) {
-            return array($job->getData(), $job->getId());
+            return array($job->getData(), $job);
         }
 
         return array(null, null);
@@ -70,7 +70,6 @@ class PheanstalkDriver implements \Bernard\Driver
      */
     public function acknowledgeMessage($queueName, $receipt)
     {
-        $receipt = new Job($receipt, null);
         $this->pheanstalk->delete($receipt);
     }
 

--- a/src/Bernard/Queue/PersistentQueue.php
+++ b/src/Bernard/Queue/PersistentQueue.php
@@ -27,7 +27,7 @@ class PersistentQueue extends AbstractQueue
 
         $this->driver   = $driver;
         $this->serializer  = $serializer;
-        $this->receipts = array();
+        $this->receipts = new \SplObjectStorage;
 
         $this->register();
     }
@@ -79,10 +79,10 @@ class PersistentQueue extends AbstractQueue
     {
         $this->errorIfClosed();
 
-        if ($receipt = array_search($envelope, $this->receipts, true)) {
-            $this->driver->acknowledgeMessage($this->name, $receipt);
+        if ($this->receipts->contains($envelope)) {
+            $this->driver->acknowledgeMessage($this->name, $this->receipts[$envelope]);
 
-            unset($this->receipts[$receipt]);
+            unset($this->receipts[$envelope]);
         }
     }
 
@@ -102,7 +102,9 @@ class PersistentQueue extends AbstractQueue
         if ($serialized) {
             $envelope = $this->serializer->unserialize($serialized);
 
-            return $this->receipts[$receipt] = $envelope;
+            $this->receipts[$envelope] = $receipt;
+
+            return $envelope;
         }
     }
 

--- a/src/Bernard/Queue/PersistentQueue.php
+++ b/src/Bernard/Queue/PersistentQueue.php
@@ -82,7 +82,7 @@ class PersistentQueue extends AbstractQueue
         if ($this->receipts->contains($envelope)) {
             $this->driver->acknowledgeMessage($this->name, $this->receipts[$envelope]);
 
-            unset($this->receipts[$envelope]);
+            $this->receipts->detach($envelope);
         }
     }
 
@@ -102,7 +102,7 @@ class PersistentQueue extends AbstractQueue
         if ($serialized) {
             $envelope = $this->serializer->unserialize($serialized);
 
-            $this->receipts[$envelope] = $receipt;
+            $this->receipts->attach($envelope, $receipt);
 
             return $envelope;
         }

--- a/tests/Bernard/Tests/Driver/PheanstalkDriverTest.php
+++ b/tests/Bernard/Tests/Driver/PheanstalkDriverTest.php
@@ -65,7 +65,7 @@ class PheanstalkDriverTest extends \PHPUnit_Framework_TestCase
         $this->pheanstalk->expects($this->once())->method('delete')
             ->with($this->isInstanceOf('Pheanstalk\Job'));
 
-        $this->driver->acknowledgeMessage('my-queue', 'receipt1');
+        $this->driver->acknowledgeMessage('my-queue', new Job(1, null));
     }
 
     public function testItPeeksInAQueue()
@@ -89,20 +89,20 @@ class PheanstalkDriverTest extends \PHPUnit_Framework_TestCase
             ->expects($this->at(0))
             ->method('reserveFromTube')
             ->with($this->equalTo('my-queue1'), $this->equalTo(5))
-            ->will($this->returnValue(new Job(1, 'message1')));
+            ->will($this->returnValue($job1 = new Job(1, 'message1')));
         $this->pheanstalk
             ->expects($this->at(1))
             ->method('reserveFromTube')
             ->with($this->equalTo('my-queue2'), $this->equalTo(5))
-            ->will($this->returnValue(new Job(2, 'message2')));
+            ->will($this->returnValue($job2 = new Job(2, 'message2')));
         $this->pheanstalk
             ->expects($this->at(1))
             ->method('reserveFromTube')
             ->with($this->equalTo('my-queue2'), $this->equalTo(5))
             ->will($this->returnValue(null));
 
-        $this->assertEquals(array('message1', 1), $this->driver->popMessage('my-queue1'));
-        $this->assertEquals(array('message2', 2), $this->driver->popMessage('my-queue2'));
+        $this->assertEquals(array('message1', $job1), $this->driver->popMessage('my-queue1'));
+        $this->assertEquals(array('message2', $job2), $this->driver->popMessage('my-queue2'));
         $this->assertEquals(array(null, null), $this->driver->popMessage('my-queue2'));
     }
 }


### PR DESCRIPTION
Currently the returned receipt must be scalar as it is used as a key in an array. For example pheanstalk returns an object which could be used as a receipt, so that the object does not have to be reinstantiated from the ID (which is saved as receipt).

Using an object store solves this problem. Also, it should have a better performance, as the previous implementation used array_search to look for the Envelope in the array.