### PR TITLE
[BC Break] Moves symfony and pimple routers under the Router namespace

### DIFF
--- a/src/Bernard/Router/ContainerAwareRouter.php
+++ b/src/Bernard/Router/ContainerAwareRouter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bernard\Symfony;
+namespace Bernard\Router;
 
 use Bernard\Envelope;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -8,7 +8,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * @package Bernard
  */
-class ContainerAwareRouter extends \Bernard\Router\SimpleRouter
+class ContainerAwareRouter extends SimpleRouter
 {
     /**
      * @param ContainerInterface $container

--- a/src/Bernard/Router/PimpleAwareRouter.php
+++ b/src/Bernard/Router/PimpleAwareRouter.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace Bernard\Pimple;
+namespace Bernard\Router;
 
 use Pimple;
 
 /**
  * @package Bernard
  */
-class PimpleAwareRouter extends \Bernard\Router\SimpleRouter
+class PimpleAwareRouter extends SimpleRouter
 {
     protected $pimple;
 

--- a/tests/Bernard/Tests/Router/ContainerAwareRouterTest.php
+++ b/tests/Bernard/Tests/Router/ContainerAwareRouterTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Bernard\Tests\Symfony;
+namespace Bernard\Tests\Router;
 
 use Bernard\Envelope;
 use Bernard\Message\DefaultMessage;
-use Bernard\Symfony\ContainerAwareRouter;
+use Bernard\Router\ContainerAwareRouter;
 use Symfony\Component\DependencyInjection\Container;
 
 class ContainerAwareRouterTest extends \PHPUnit_Framework_TestCase

--- a/tests/Bernard/Tests/Router/PimpleAwareRouterTest.php
+++ b/tests/Bernard/Tests/Router/PimpleAwareRouterTest.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace Bernard\Tests\Pimple;
+namespace Bernard\Tests\Router;
 
 use Bernard\Envelope;
 use Bernard\Message\DefaultMessage;
-use Bernard\Pimple\PimpleAwareRouter;
+use Bernard\Router\PimpleAwareRouter;
 use Pimple;
 
 class PimpleAwareRouterTest extends \PHPUnit_Framework_TestCase


### PR DESCRIPTION
As a workaround the following can prevent code break because of this PR:

``` php
class_alias('Bernard\Router\ContainerAwareRoute', 'Bernard\Symfony\ContainerAwareRoute');
class_alias('Bernard\Router\PimpleAwareRoute', 'Bernard\Pimple\PimpleAwareRoute');
```