### PR TITLE
Fixes queue peek

### DIFF
--- a/src/Queue.php
+++ b/src/Queue.php
@@ -29,7 +29,7 @@ interface Queue extends \Countable
      *
      * @return array
      */
-    public function peek($index = 1, $limit = 20);
+    public function peek($index = 0, $limit = 20);
 
     /**
      * SQS requires that a message will be acknowledged or it will be moved back

--- a/src/Queue/InMemoryQueue.php
+++ b/src/Queue/InMemoryQueue.php
@@ -64,7 +64,7 @@ class InMemoryQueue extends AbstractQueue
     /**
      * {@inheritDoc}
      */
-    public function peek($index = 1, $limit = 20)
+    public function peek($index = 0, $limit = 20)
     {
         $this->errorIfClosed();
 

--- a/src/Queue/InMemoryQueue.php
+++ b/src/Queue/InMemoryQueue.php
@@ -70,9 +70,9 @@ class InMemoryQueue extends AbstractQueue
 
         $envelopes = array();
         $queue = clone $this->queue;
-        $key = -1;
+        $key = 0;
 
-        while ($this->count() && count($envelopes) < $limit && $envelope = $queue->dequeue()) {
+        while ($queue->count() && count($envelopes) < $limit && $envelope = $queue->dequeue()) {
             if ($key++ < $index) {
                 continue;
             }

--- a/tests/Queue/InMemoryQueueTest.php
+++ b/tests/Queue/InMemoryQueueTest.php
@@ -32,7 +32,7 @@ class InMemoryQueueTest extends AbstractQueueTest
         $queue->enqueue($envelope3 = $this->getEnvelope());
 
         $this->assertCount(4, $queue);
-        $this->assertEquals(array(
+        $this->assertSame(array(
             $envelope1,
             $envelope2,
         ), $queue->peek(1, 2));


### PR DESCRIPTION
For some reasons `SplQueue::key` always returns 0. So I just fixed some bugs. I am going to investigate it, but I wanted this fixed, so I can move in with spec tests.