### PR TITLE
QueueName as optional argument in ProduceCommand

### DIFF
--- a/src/Command/ProduceCommand.php
+++ b/src/Command/ProduceCommand.php
@@ -52,7 +52,6 @@ class ProduceCommand extends \Symfony\Component\Console\Command\Command
             throw new \RuntimeException('Could not decode invalid JSON [' . json_last_error() . ']');
         }
 
-        $this->producer->produce(new DefaultMessage($name, $message), $queue);
         $this->producer->produce(new DefaultMessage($name, $message), $queueName);
     }
 }

--- a/src/Command/ProduceCommand.php
+++ b/src/Command/ProduceCommand.php
@@ -35,6 +35,7 @@ class ProduceCommand extends \Symfony\Component\Console\Command\Command
             ->addOption('queue', null, InputOption::VALUE_OPTIONAL, 'Name of a queue to add this job to. By default the queue is guessed from the message name.', null)
             ->addArgument('name', InputArgument::REQUIRED, 'Name for the message eg. "ImportUsers".')
             ->addArgument('message', InputArgument::OPTIONAL, 'JSON encoded string that is used for message properties.')
+            ->addArgument('queueName', InputArgument::OPTIONAL, 'Name of the queue to put the message in.')
         ;
     }
 
@@ -43,14 +44,15 @@ class ProduceCommand extends \Symfony\Component\Console\Command\Command
      */
     public function execute(InputInterface $input, OutputInterface $output)
     {
-        $name    = $input->getArgument('name');
-        $message = json_decode($input->getArgument('message'), true) ?: array();
-        $queue   = $input->getOption('queue');
+        $name      = $input->getArgument('name');
+        $message   = json_decode($input->getArgument('message'), true) ?: array();
+        $queueName = $input->getArgument('queueName');
 
         if (json_last_error()) {
             throw new \RuntimeException('Could not decode invalid JSON [' . json_last_error() . ']');
         }
 
         $this->producer->produce(new DefaultMessage($name, $message), $queue);
+        $this->producer->produce(new DefaultMessage($name, $message), $queueName);
     }
 }

--- a/tests/Command/ProduceCommandTest.php
+++ b/tests/Command/ProduceCommandTest.php
@@ -55,4 +55,20 @@ class ProduceCommandTest extends \PHPUnit_Framework_TestCase
             'message' => '{"foo":"bar"}'
         ));
     }
+
+    public function testItTakesQueueName()
+    {
+        $queueNameInput = 'test-queue';
+        $this->producer->expects($this->once())
+                       ->method('produce')
+                       ->with($this->anything(), $this->equalTo($queueNameInput));
+
+        $command = new ProduceCommand($this->producer);
+        $tester = new CommandTester($command);
+        $tester->execute(array(
+            'name'      => 'SendNewsletter',
+            'message'   => '{"foo":"bar"}',
+            'queueName' => $queueNameInput,
+        ));
+    }
 }


### PR DESCRIPTION
This is handy not at last to circumvent queue name guessing, which can lead to difficult situations.

E.g. the message name "SendNewsletter" resolves to a guessed queue name "send-newsletter". When configuring a queue map in Symfony ([PR in BernardBundle](https://github.com/bernardphp/BernardBundle/pull/12)) like this:

```yaml
bernard_bernard:
    options:
        queue_map:
            send-newsletter: https://sqs.eu-west-1.amazonaws.com/...
```

the resulting queue map key will unfortunately be "send_newsletter" with an underscore instead of a hiven. When calling the ProduceCommand in that configuration, the guessed and the present queue names do not match, and you'll end up with a `Aws\Sqs\Exception\SqsException`: "The specified queue does not exist for this wsdl version" (which is not really helpful, someone should improve that, too).

As guessing per se cannot be perfect, I don't want to mess with it. Instead, I think an optional argument for the ProduceCommand is a good solution.