### PR TITLE
More helpful exception message

### DIFF
--- a/src/Driver/SqsDriver.php
+++ b/src/Driver/SqsDriver.php
@@ -179,7 +179,7 @@ class SqsDriver extends AbstractPrefetchDriver
         } catch (SqsException $exception) {
             if ($exception->getExceptionCode() === 'AWS.SimpleQueueService.NonExistentQueue') {
                 throw new SqsException(
-                    'The queue "' . $queueName . '" is neither aliased locally to an AWS URL nor could it be resolved by SQS.',
+                    'The queue "' . $queueName . '" is neither aliased locally to an SQS URL nor could it be resolved by SQS.',
                     $exception->getCode(),
                     $exception
                 );

--- a/src/Driver/SqsDriver.php
+++ b/src/Driver/SqsDriver.php
@@ -162,6 +162,7 @@ class SqsDriver extends AbstractPrefetchDriver
      * @param string $queueName
      *
      * @return mixed
+     * @throws SqsException
      */
     protected function resolveUrl($queueName)
     {
@@ -169,9 +170,23 @@ class SqsDriver extends AbstractPrefetchDriver
             return $this->queueUrls[$queueName];
         }
 
-        $result = $this->sqs->getQueueUrl(array(
-            'QueueName' => $queueName,
-        ));
+        try {
+            $result = $this->sqs->getQueueUrl(
+                array(
+                    'QueueName' => $queueName,
+                )
+            );
+        } catch (SqsException $exception) {
+            if ($exception->getExceptionCode() === 'AWS.SimpleQueueService.NonExistentQueue') {
+                throw new SqsException(
+                    'The queue "' . $queueName . '" is neither aliased locally to an AWS URL nor could it be resolved by SQS.',
+                    $exception->getCode(),
+                    $exception
+                );
+            }
+
+            throw $exception;
+        }
 
         if ($result && $queueUrl = $result->get('QueueUrl')) {
             return $this->queueUrls[$queueName] = $queueUrl;


### PR DESCRIPTION
When you e.g. try to push a message to a SQS queue by an unaliased name and SQS cannot resolve the name, you usually get a `\Aws\Sqs\Exception\SqsException`: "The specified queue does not exist for this wsdl version", which is quite confusing.

With this PR, the exception gets wrapped in one with a more helpful message: "'The queue "' . $queueName . '" is neither aliased locally to an SQS URL nor could it be resolved by SQS.'"