### PR TITLE
RabbitMQ/PhpAmqp Driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ Currently these are the supported backends, with more coming with each release:
  * Iron MQ
  * Doctrine DBAL
  * Pheanstalk
+ * PhpAmqp / RabbitMQ
 
 You can learn more on our website about Bernard and its [related projects][website] or just dive directly into [the
 documentation][documentation].

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
         "iron-io/iron_mq"              : "~1.4",
         "aws/aws-sdk-php"              : "~2.4",
         "pda/pheanstalk"               : "~3.0",
-        "league/container"             : "~1.0"
+        "league/container"             : "~1.0",
+        "videlalvaro/php-amqplib"      : "~2.5"
     },
 
     "extra" : {

--- a/doc/drivers.rst
+++ b/doc/drivers.rst
@@ -10,6 +10,7 @@ Several different types of drivers are supported. Currently these are available:
 * `Amazon SQS`_
 * `Google AppEngine`_
 * `MongoDB`_
+* `PhpAmqp / RabbitMQ`_
 
 Redis Extension
 ---------------
@@ -390,3 +391,26 @@ To support message queries, the following index should also be created:
         'visible' => 1,
         'sentAt' => 1,
     ]);
+
+PhpAmqp / RabbitMQ
+------------------
+
+The RabbitMQ driver leans on the php-amqp library by Alvaro Videla.
+
+The driver should be constructed with an ``AMQPConnection`` object, an exchange name and optionally the default message
+parameters.
+
+.. code-block:: php
+
+    <?php
+
+    $connection = new \PhpAmqpLib\Connection\AMQPConnection('localhost', 5672, 'foo', 'bar');
+
+    $driver = new \Bernard\Driver\PhpAmqpDriver($connection, 'my-exchange');
+
+    // Or with default message params
+    $driver = new \Bernard\Driver\PhpAmqpDriver(
+        $connection,
+        'my-exchange',
+        ['content_type' => 'application/json', 'delivery_mode' => 2]
+    );

--- a/src/Driver/PhpAmqpDriver.php
+++ b/src/Driver/PhpAmqpDriver.php
@@ -1,0 +1,158 @@
+<?php
+
+namespace Bernard\Driver;
+
+use Bernard\Driver;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Exception\AMQPTimeoutException;
+use PhpAmqpLib\Message\AMQPMessage;
+
+class PhpAmqpDriver implements Driver
+{
+    /**
+     * @var AMQPConnection
+     */
+    private $connection;
+
+    /**
+     * @var AMQPChannel
+     */
+    private $channel;
+
+    /**
+     * @var string
+     */
+    private $exchange;
+    /**
+     * @var array|null
+     */
+    private $defaultMessageParams;
+
+    /**
+     * @param AMQPConnection $connection
+     * @param string $exchange
+     * @param array $defaultMessageParams
+     */
+    public function __construct(AMQPConnection $connection, $exchange, array $defaultMessageParams = null)
+    {
+        $this->connection = $connection;
+        $this->exchange = $exchange;
+        $this->defaultMessageParams = $defaultMessageParams;
+
+        $this->channel = $this->connection->channel();
+    }
+
+    /**
+     * Returns a list of all queue names.
+     *
+     * @return array
+     */
+    public function listQueues()
+    {
+
+    }
+
+    /**
+     * Create a queue.
+     *
+     * @param string $queueName
+     */
+    public function createQueue($queueName)
+    {
+        $this->channel->exchange_declare($this->exchange, 'direct', false, true, false);
+        $this->channel->queue_declare($queueName, false, true, false, false);
+        $this->channel->queue_bind($queueName, $this->exchange);
+    }
+
+    /**
+     * Count the number of messages in queue. This can be a approximately number.
+     *
+     * @return integer
+     */
+    public function countMessages($queueName)
+    {
+
+    }
+
+    /**
+     * Insert a message at the top of the queue.
+     *
+     * @param string $queueName
+     * @param string $message
+     */
+    public function pushMessage($queueName, $message)
+    {
+        $amqpMessage = new AMQPMessage($message, $this->defaultMessageParams);
+        $this->channel->basic_publish($amqpMessage, $this->exchange);
+    }
+
+    /**
+     * Remove the next message in line. And if no message is available
+     * wait $interval seconds.
+     *
+     * @param string $queueName
+     * @param integer $interval
+     *
+     * @return array An array like array($message, $receipt);
+     */
+    public function popMessage($queueName, $interval = 5)
+    {
+        $message = $this->channel->basic_get($queueName);
+        if (!$message) {
+            // sleep for 10 ms to prevent hammering CPU
+            usleep(10000);
+            return [null, null];
+        }
+
+        return [$message->body, $message->get('delivery_tag')];
+    }
+
+    /**
+     * If the driver supports it, this will be called when a message
+     * have been consumed.
+     *
+     * @param string $queueName
+     * @param mixed $receipt
+     */
+    public function acknowledgeMessage($queueName, $receipt)
+    {
+        $this->channel->basic_ack($receipt);
+    }
+
+    /**
+     * Returns a $limit numbers of messages without removing them
+     * from the queue.
+     *
+     * @param string $queueName
+     * @param integer $index
+     * @param integer $limit
+     */
+    public function peekQueue($queueName, $index = 0, $limit = 20)
+    {
+
+    }
+
+    /**
+     * Removes the queue.
+     *
+     * @param string $queueName
+     */
+    public function removeQueue($queueName)
+    {
+
+    }
+
+    /**
+     * @return array
+     */
+    public function info()
+    {
+
+    }
+
+    public function __destruct()
+    {
+        $this->channel->close();
+    }
+}

--- a/tests/Driver/PhpAmqpDriverTest.php
+++ b/tests/Driver/PhpAmqpDriverTest.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Bernard\Tests\Driver;
+
+use Bernard\Driver\PhpAmqpDriver;
+use PhpAmqpLib\Channel\AMQPChannel;
+use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Message\AMQPMessage;
+
+class PhpAmqpDriverTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var AMQPConnection
+     */
+    private $phpAmqpConnection;
+
+    /**
+     * @var AMQPChannel
+     */
+    private $phpAmqpChannel;
+
+    /**
+     * @var PhpAmqpDriver
+     */
+    private $driver;
+
+    const EXCHANGE_NAME = 'foo-exchange';
+
+    protected function setUp()
+    {
+        $this->phpAmqpChannel = $this->getMock(
+            '\PhpAmqpLib\Channel\AMQPChannel',
+            array(
+                'basic_publish',
+                'basic_get',
+                'basic_ack',
+                'exchange_declare',
+                'queue_declare',
+                'queue_bind'
+            ),
+            array(),
+            '',
+            false
+        );
+
+        $this->phpAmqpConnection = $this->getMock(
+            '\PhpAmqpLib\Connection\AMQPConnection',
+            array('channel'),
+            array(),
+            '',
+            false
+        );
+
+        $this->phpAmqpConnection
+            ->expects($this->any())
+            ->method('channel')
+            ->willReturn($this->phpAmqpChannel);
+
+        $this->driver = new PhpAmqpDriver($this->phpAmqpConnection, self::EXCHANGE_NAME);
+    }
+
+    public function testItImplementsDriverInterface()
+    {
+        $this->assertInstanceOf('Bernard\Driver', $this->driver);
+    }
+
+    public function testItCreatesQueue()
+    {
+        $this->phpAmqpChannel
+            ->expects($this->once())
+            ->method('exchange_declare')
+            ->with(self::EXCHANGE_NAME, 'direct', false, true, false)
+        ;
+        $this->phpAmqpChannel
+            ->expects($this->once())
+            ->method('queue_declare')
+            ->with('foo-queue', false, true, false, false)
+        ;
+        $this->phpAmqpChannel
+            ->expects($this->once())
+            ->method('queue_bind')
+            ->with('foo-queue', self::EXCHANGE_NAME)
+        ;
+
+        $this->driver->createQueue('foo-queue');
+    }
+
+    public function testItPushesMessages()
+    {
+        $this->phpAmqpChannel
+            ->expects($this->once())
+            ->method('basic_publish')
+            ->with(
+                $this->callback(function(AMQPMessage $message) {
+                    return $message->body == 'dummy push message';
+                }),
+                self::EXCHANGE_NAME
+            );
+        $this->driver->pushMessage('not-relevant', 'dummy push message');
+    }
+
+    public function testItUsesDefaultParameters()
+    {
+        $this->driver = new PhpAmqpDriver(
+            $this->phpAmqpConnection,
+            self::EXCHANGE_NAME,
+            array('delivery_mode' => 2)
+        );
+
+        $this->phpAmqpChannel
+            ->expects($this->once())
+            ->method('basic_publish')
+            ->with(
+                $this->callback(function(AMQPMessage $message) {
+                    return $message->get('delivery_mode') === 2;
+                }),
+                self::EXCHANGE_NAME
+            );
+        $this->driver->pushMessage('not-relevant', 'dummy push message');
+    }
+
+    public function testItPopsMessages()
+    {
+        $amqpMessage = new AMQPMessage('bar');
+        $amqpMessage->delivery_info['delivery_tag'] = 'alright';
+
+        $this->phpAmqpChannel
+            ->expects($this->once())
+            ->method('basic_get')
+            ->with($this->equalTo('foo-queue'))
+            ->willReturn($amqpMessage);
+
+        $this->assertEquals(['bar', 'alright'], $this->driver->popMessage('foo-queue'));
+    }
+
+    public function testItPopsArrayWithNullsWhenThereAreNoMessages()
+    {
+        $this->phpAmqpChannel
+            ->expects($this->once())
+            ->method('basic_get')
+            ->with($this->equalTo('foo-queue'))
+            ->willReturn(null);
+
+        $this->assertEquals([null, null], $this->driver->popMessage('foo-queue'));
+    }
+
+    public function testItAcknowledgesMessage()
+    {
+        $this->phpAmqpChannel
+            ->expects($this->once())
+            ->method('basic_ack')
+            ->with('delivery-tag');
+
+        $this->driver->acknowledgeMessage('irrelevant', 'delivery-tag');
+    }
+}


### PR DESCRIPTION
Hi there,

here is the driver that I've built to use Bernard with RabbitMQ/PhpAmqp.

The php-amqp lib receives messages from a consumer via a callback (async), which clashes a bit with  Bernard's `popMessage` (sync). The workaround in this driver turns out to be hard to test. Suggestions are more than welcome!

Furthermore it is important that the QoS on the channel is set to have a maximum of one unacked message at a time.

Shouts out to @rskuipers for helping me with this.

Possibly solves #115 

## Todo
- [x] Add documentation
- [x] Fix reason CI build failed