### PR TITLE
Doctrine commands

### DIFF
--- a/doc/drivers.rst
+++ b/doc/drivers.rst
@@ -103,11 +103,11 @@ as appropriate for your use case.
     ];
 
     // To create a new application from scratch ...
-    $helperSet = new HelperSet(['db' => new ConnectionHelper($connection)]);
+    $helperSet = new HelperSet(['connection' => new ConnectionHelper($connection)]);
     $cli = new Application('Bernard Doctrine Command Line Interface');
     $cli->setCatchExceptions(true);
-    $cli->addCommands($commands);
     $cli->setHelperSet($helperSet);
+    $cli->addCommands($commands);
 
     // ... or, if you're using Doctrine ORM 2.5+,
     // just re-use the existing Doctrine application ...
@@ -117,6 +117,12 @@ as appropriate for your use case.
 
     // Finally, run the application
     $cli->run();
+
+And run the console application like so:
+
+.. code-block:: shell
+
+    php doctrine.php bernard:doctrine:create
 
 Alternatively, use the following method for creating the tables manually.
 

--- a/doc/drivers.rst
+++ b/doc/drivers.rst
@@ -78,7 +78,47 @@ the message popped from the queue.
 
     To use Doctrine DBAL remember to setup the correct schema.
 
-Use the following method for creating the needed bernard tables.
+Creating the needed bernard tables can be automated by creating a console
+application with `custom commands <http://doctrine-orm.readthedocs.org/en/stable/reference/tools.html#adding-own-commands>`_.
+Just configure a `connection <http://docs.doctrine-project.org/projects/doctrine-dbal/en/latest/reference/configuration.html#getting-a-connection>`_
+or `entity manager <http://docs.doctrine-project.org/projects/doctrine-orm/en/latest/tutorials/getting-started.html#obtaining-the-entitymanager>`_
+as appropriate for your use case.
+
+.. code-block:: php
+
+    <?php
+    // doctrine.php
+
+    use Bernard\Command\Doctrine as BernardCommands;
+    use Doctrine\DBAL\Tools\Console\ConsoleRunner;
+    use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
+    use Symfony\Component\Console\Helper\Application;
+    use Symfony\Component\Console\Helper\HelperSet;
+
+    $connection = ...;
+    $commands = [
+        new BernardCommands\CreateCommand,
+        new BernardCommands\DropCommand,
+        new BernardCommands\UpdateCommand,
+    ];
+
+    // To create a new application from scratch ...
+    $helperSet = new HelperSet(['db' => new ConnectionHelper($connection)]);
+    $cli = new Application('Bernard Doctrine Command Line Interface');
+    $cli->setCatchExceptions(true);
+    $cli->addCommands($commands);
+    $cli->setHelperSet($helperSet);
+
+    // ... or, if you're using Doctrine ORM 2.5+,
+    // just re-use the existing Doctrine application ...
+    $entityManager = ...;
+    $helperSet = ConsoleRunner::createHelperSet($entityManager);
+    $cli = ConsoleRunner::createApplication($helperSet, $commands);
+
+    // Finally, run the application
+    $cli->run();
+
+Alternatively, use the following method for creating the tables manually.
 
 .. code-block:: php
 

--- a/doc/drivers.rst
+++ b/doc/drivers.rst
@@ -92,7 +92,7 @@ as appropriate for your use case.
     use Bernard\Command\Doctrine as BernardCommands;
     use Doctrine\DBAL\Tools\Console\ConsoleRunner;
     use Doctrine\DBAL\Tools\Console\Helper\ConnectionHelper;
-    use Symfony\Component\Console\Helper\Application;
+    use Symfony\Component\Console\Application;
     use Symfony\Component\Console\Helper\HelperSet;
 
     $connection = ...;

--- a/src/Command/Doctrine/AbstractCommand.php
+++ b/src/Command/Doctrine/AbstractCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Bernard\Command\Doctrine;
+
+use Bernard\Doctrine\MessagesSchema;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer as Synchronizer;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * @package Bernard
+ */
+abstract class AbstractCommand extends Command
+{
+    protected $name = 'abstract';
+
+    public function __construct()
+    {
+        parent::__construct('bernard:doctrine:' . $this->name);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function configure()
+    {
+        $this->addOption('dump-sql', null, InputOption::VALUE_NONE, 'Output generated SQL statements instead of applying them');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $schema = new Schema;
+        MessagesSchema::create($schema);
+        $sync = $this->getSynchronizer($this->getHelper('connection')->getConnection());
+
+        if ($input->getOption('dump-sql')) {
+            $output->writeln(implode(';' . PHP_EOL, $this->getSql($sync, $schema)) . ';');
+        } else {
+            $output->writeln('<comment>ATTENTION</comment>: This operation should not be executed in a production environment.' . PHP_EOL);
+            $output->writeln('Applying database schema changes...');
+            $this->applySql($sync, $schema);
+            $output->writeln('Schema changes applied successfully!'); 
+        }
+    }
+
+    /**
+     * @return \Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer
+     */
+    protected function getSynchronizer(Connection $connection)
+    {
+        return new Synchronizer($connection);
+    }
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer $sync
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     * @return array
+     */
+    abstract protected function getSql(Synchronizer $sync, Schema $schema);
+
+    /**
+     * @param \Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer $sync
+     * @param \Doctrine\DBAL\Schema\Schema $schema
+     */
+    abstract protected function applySql(Synchronizer $sync, Schema $schema);
+}

--- a/src/Command/Doctrine/AbstractCommand.php
+++ b/src/Command/Doctrine/AbstractCommand.php
@@ -16,11 +16,9 @@ use Symfony\Component\Console\Output\OutputInterface;
  */
 abstract class AbstractCommand extends Command
 {
-    protected $name = 'abstract';
-
-    public function __construct()
+    public function __construct($name)
     {
-        parent::__construct('bernard:doctrine:' . $this->name);
+        parent::__construct('bernard:doctrine:' . $name);
     }
 
     /**
@@ -42,12 +40,13 @@ abstract class AbstractCommand extends Command
 
         if ($input->getOption('dump-sql')) {
             $output->writeln(implode(';' . PHP_EOL, $this->getSql($sync, $schema)) . ';');
-        } else {
-            $output->writeln('<comment>ATTENTION</comment>: This operation should not be executed in a production environment.' . PHP_EOL);
-            $output->writeln('Applying database schema changes...');
-            $this->applySql($sync, $schema);
-            $output->writeln('Schema changes applied successfully!'); 
+            return;
         }
+
+        $output->writeln('<comment>ATTENTION</comment>: This operation should not be executed in a production environment.' . PHP_EOL);
+        $output->writeln('Applying database schema changes...');
+        $this->applySql($sync, $schema);
+        $output->writeln('Schema changes applied successfully!');
     }
 
     /**

--- a/src/Command/Doctrine/CreateCommand.php
+++ b/src/Command/Doctrine/CreateCommand.php
@@ -10,7 +10,10 @@ use Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer as Synchronizer
  */
 class CreateCommand extends AbstractCommand
 {
-    protected $name = 'create';
+    public function __construct()
+    {
+        parent::__construct('create');
+    }
 
     /**
      * {@inheritDoc}

--- a/src/Command/Doctrine/CreateCommand.php
+++ b/src/Command/Doctrine/CreateCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bernard\Command\Doctrine;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer as Synchronizer;
+
+/**
+ * @package Bernard
+ */
+class CreateCommand extends AbstractCommand
+{
+    protected $name = 'create';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getSql(Synchronizer $sync, Schema $schema)
+    {
+        return $sync->getCreateSchema($schema);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function applySql(Synchronizer $sync, Schema $schema)
+    {
+        $sync->createSchema($schema);
+    }
+}

--- a/src/Command/Doctrine/DropCommand.php
+++ b/src/Command/Doctrine/DropCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bernard\Command\Doctrine;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer as Synchronizer;
+
+/**
+ * @package Bernard
+ */
+class DropCommand extends AbstractCommand
+{
+    protected $name = 'drop';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getSql(Synchronizer $sync, Schema $schema)
+    {
+        return $sync->getDropSchema($schema);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function applySql(Synchronizer $sync, Schema $schema)
+    {
+        $sync->dropSchema($schema);
+    }
+}

--- a/src/Command/Doctrine/DropCommand.php
+++ b/src/Command/Doctrine/DropCommand.php
@@ -10,7 +10,10 @@ use Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer as Synchronizer
  */
 class DropCommand extends AbstractCommand
 {
-    protected $name = 'drop';
+    public function __construct()
+    {
+        parent::__construct('drop');
+    }
 
     /**
      * {@inheritDoc}

--- a/src/Command/Doctrine/UpdateCommand.php
+++ b/src/Command/Doctrine/UpdateCommand.php
@@ -10,7 +10,10 @@ use Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer as Synchronizer
  */
 class UpdateCommand extends AbstractCommand
 {
-    protected $name = 'update';
+    public function __construct()
+    {
+        parent::__construct('update');
+    }
 
     /**
      * {@inheritDoc}

--- a/src/Command/Doctrine/UpdateCommand.php
+++ b/src/Command/Doctrine/UpdateCommand.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bernard\Command\Doctrine;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\DBAL\Schema\Synchronizer\SingleDatabaseSynchronizer as Synchronizer;
+
+/**
+ * @package Bernard
+ */
+class UpdateCommand extends AbstractCommand
+{
+    protected $name = 'update';
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getSql(Synchronizer $sync, Schema $schema)
+    {
+        return $sync->getUpdateSchema($schema);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function applySql(Synchronizer $sync, Schema $schema)
+    {
+        $sync->updateSchema($schema);
+    }
+}

--- a/tests/Command/Doctrine/AbstractCommandTest.php
+++ b/tests/Command/Doctrine/AbstractCommandTest.php
@@ -22,7 +22,9 @@ class AbstractCommandTest extends \PHPUnit_Framework_TestCase
             ->will($this->returnValue($connection));
 
         $this->command = $this->getMockBuilder('Bernard\\Command\\Doctrine\\AbstractCommand')
-            ->setMethods(['getSql', 'applySql', 'getHelper'])->getMock();
+            ->setMethods(['getSql', 'applySql', 'getHelper'])
+            ->setConstructorArgs(['abstract'])
+            ->getMock();
         $this->command
             ->expects($this->any())
             ->method('getHelper')

--- a/tests/Command/Doctrine/AbstractCommandTest.php
+++ b/tests/Command/Doctrine/AbstractCommandTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace Bernard\Tests\Command\Doctrine;
+
+use Bernard\Command\Doctrine\AbstractCommand;
+use Symfony\Component\Console\Tester\CommandTester;
+
+class AbstractCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected $command;
+
+    public function setUp()
+    {
+        $connection = $this->getMockBuilder('Doctrine\\DBAL\\Connection')
+            ->disableOriginalConstructor()->getMock();
+
+        $helper = $this->getMockBuilder('Doctrine\\DBAL\\Tools\\Console\\Helper\\ConnectionHelper')
+            ->disableOriginalConstructor()->getMock();
+        $helper
+            ->expects($this->any())
+            ->method('getConnection')
+            ->will($this->returnValue($connection));
+
+        $this->command = $this->getMockBuilder('Bernard\\Command\\Doctrine\\AbstractCommand')
+            ->setMethods(['getSql', 'applySql', 'getHelper'])->getMock();
+        $this->command
+            ->expects($this->any())
+            ->method('getHelper')
+            ->with('connection')
+            ->will($this->returnValue($helper));
+    }
+
+    public function testExecuteWithDumpSql()
+    {
+        $this->command
+            ->expects($this->once())
+            ->method('getSql')
+            ->with(
+                $this->isInstanceOf('Doctrine\\DBAL\\Schema\\Synchronizer\\SingleDatabaseSynchronizer'),
+                $this->isInstanceOf('Doctrine\\DBAL\\Schema\\Schema')
+            )
+            ->will($this->returnValue([]));
+
+        $tester = new CommandTester($this->command);
+        $tester->execute([
+            '--dump-sql' => true,
+        ]);
+    }
+
+    public function testExecuteWithoutDumpSql()
+    {
+        $this->command
+            ->expects($this->once())
+            ->method('applySql')
+            ->with(
+                $this->isInstanceOf('Doctrine\\DBAL\\Schema\\Synchronizer\\SingleDatabaseSynchronizer'),
+                $this->isInstanceOf('Doctrine\\DBAL\\Schema\\Schema')
+            );
+
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+    }
+}

--- a/tests/Command/Doctrine/BaseCommandTest.php
+++ b/tests/Command/Doctrine/BaseCommandTest.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Bernard\Tests\Command\Doctrine;
+
+use Symfony\Component\Console\Tester\CommandTester;
+
+abstract class BaseCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected $command;
+
+    protected $sync;
+
+    public function setUp()
+    {
+        $connection = $this->getMockBuilder('Doctrine\\DBAL\\Connection')
+            ->disableOriginalConstructor()->getMock();
+
+        $this->sync = $this->getMockBuilder('Doctrine\\DBAL\\Schema\\Synchronizer\\SingleDatabaseSynchronizer')
+            ->disableOriginalConstructor()->getMock();
+
+        $helper = $this->getMockBuilder('Doctrine\\DBAL\\Tools\\Console\\Helper\\ConnectionHelper')
+            ->disableOriginalConstructor()->getMock();
+        $helper
+            ->expects($this->any())
+            ->method('getConnection')
+            ->will($this->returnValue($connection));
+
+        $this->command = $this->getMockBuilder('Bernard\\Command\\Doctrine\\' . $this->getShortClassName())
+            ->setMethods(['getSynchronizer', 'getHelper'])
+            ->setConstructorArgs([$connection])
+            ->getMock();
+        $this->command
+            ->expects($this->any())
+            ->method('getSynchronizer')
+            ->with($connection)
+            ->will($this->returnValue($this->sync));
+        $this->command
+            ->expects($this->any())
+            ->method('getHelper')
+            ->with('connection')
+            ->will($this->returnValue($helper));
+    }
+
+    public function testExecuteWithDumpSql()
+    {
+        $this->sync
+            ->expects($this->once())
+            ->method($this->getSqlMethod())
+            ->with($this->isInstanceOf('Doctrine\\DBAL\\Schema\\Schema'))
+            ->will($this->returnValue([]));
+
+        $tester = new CommandTester($this->command);
+        $tester->execute([
+            '--dump-sql' => true,
+        ]);
+    }
+
+    public function testExecuteWithoutDumpSql()
+    {
+        $this->sync
+            ->expects($this->once())
+            ->method($this->applySqlMethod())
+            ->with($this->isInstanceOf('Doctrine\\DBAL\\Schema\\Schema'));
+
+        $tester = new CommandTester($this->command);
+        $tester->execute([]);
+    }
+
+    /**
+     * @return string
+     */
+    abstract public function getShortClassName();
+
+    /**
+     * @return string
+     */
+    abstract public function getSqlMethod();
+
+    /**
+     * @return string
+     */
+    abstract public function applySqlMethod();
+}

--- a/tests/Command/Doctrine/CreateCommandTest.php
+++ b/tests/Command/Doctrine/CreateCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bernard\Tests\Command\Doctrine;
+
+class CreateCommandTest extends BaseCommandTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getShortClassName()
+    {
+        return 'CreateCommand';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSqlMethod()
+    {
+        return 'getCreateSchema';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applySqlMethod()
+    {
+        return 'createSchema';
+    }
+}

--- a/tests/Command/Doctrine/DropCommandTest.php
+++ b/tests/Command/Doctrine/DropCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bernard\Tests\Command\Doctrine;
+
+class DropCommandTest extends BaseCommandTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getShortClassName()
+    {
+        return 'DropCommand';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSqlMethod()
+    {
+        return 'getDropSchema';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applySqlMethod()
+    {
+        return 'dropSchema';
+    }
+}

--- a/tests/Command/Doctrine/UpdateCommandTest.php
+++ b/tests/Command/Doctrine/UpdateCommandTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Bernard\Tests\Command\Doctrine;
+
+class UpdateCommandTest extends BaseCommandTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getShortClassName()
+    {
+        return 'UpdateCommand';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getSqlMethod()
+    {
+        return 'getUpdateSchema';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function applySqlMethod()
+    {
+        return 'updateSchema';
+    }
+}


### PR DESCRIPTION
To augment the [existing example](http://bernard.readthedocs.org/drivers.html#doctrine-dbal) of creating the Bernard tables when using the DBAL driver, I've created commands usable within a Symfony console application (a [custom Doctrine script](http://doctrine-orm.readthedocs.org/en/stable/reference/tools.html#adding-own-commands), for example) to create, drop, and (in the unlikely event that it becomes needed) update the Bernard database tables. These are roughly equivalent to the `orm:schema-tool` [Doctrine ORM console commands](http://doctrine-orm.readthedocs.org/en/stable/reference/tools.html#command-overview).

This PR includes tests for these commands as well as additions to the documentation with a working example script. Aside from some minor rewording in the documentation, the changes are entirely additive.
