### PR TITLE
PhpAmqpDriver > Use AMQPStreamConnection instead of deprecated AMQPConnection

### DIFF
--- a/doc/drivers.rst
+++ b/doc/drivers.rst
@@ -397,14 +397,14 @@ PhpAmqp / RabbitMQ
 
 The RabbitMQ driver leans on the php-amqp library by Alvaro Videla.
 
-The driver should be constructed with an ``AMQPConnection`` object, an exchange name and optionally the default message
+The driver should be constructed with an ``AMQPStreamConnection`` object, an exchange name and optionally the default message
 parameters.
 
 .. code-block:: php
 
     <?php
 
-    $connection = new \PhpAmqpLib\Connection\AMQPConnection('localhost', 5672, 'foo', 'bar');
+    $connection = new \PhpAmqpLib\Connection\AMQPStreamConnection('localhost', 5672, 'foo', 'bar');
 
     $driver = new \Bernard\Driver\PhpAmqpDriver($connection, 'my-exchange');
 

--- a/src/Driver/PhpAmqpDriver.php
+++ b/src/Driver/PhpAmqpDriver.php
@@ -4,14 +4,14 @@ namespace Bernard\Driver;
 
 use Bernard\Driver;
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Exception\AMQPTimeoutException;
 use PhpAmqpLib\Message\AMQPMessage;
 
 class PhpAmqpDriver implements Driver
 {
     /**
-     * @var AMQPConnection
+     * @var AMQPStreamConnection
      */
     private $connection;
 
@@ -30,11 +30,11 @@ class PhpAmqpDriver implements Driver
     private $defaultMessageParams;
 
     /**
-     * @param AMQPConnection $connection
+     * @param AMQPStreamConnection $connection
      * @param string $exchange
      * @param array $defaultMessageParams
      */
-    public function __construct(AMQPConnection $connection, $exchange, array $defaultMessageParams = null)
+    public function __construct(AMQPStreamConnection $connection, $exchange, array $defaultMessageParams = null)
     {
         $this->connection = $connection;
         $this->exchange = $exchange;

--- a/tests/Driver/PhpAmqpDriverTest.php
+++ b/tests/Driver/PhpAmqpDriverTest.php
@@ -4,13 +4,13 @@ namespace Bernard\Tests\Driver;
 
 use Bernard\Driver\PhpAmqpDriver;
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPConnection;
+use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
 class PhpAmqpDriverTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @var AMQPConnection
+     * @var AMQPStreamConnection
      */
     private $phpAmqpConnection;
 
@@ -44,7 +44,7 @@ class PhpAmqpDriverTest extends \PHPUnit_Framework_TestCase
         );
 
         $this->phpAmqpConnection = $this->getMock(
-            '\PhpAmqpLib\Connection\AMQPConnection',
+            '\PhpAmqpLib\Connection\AMQPStreamConnection',
             array('channel'),
             array(),
             '',


### PR DESCRIPTION
This will allow you to inject a LazyConnection in the driver.