### PR TITLE
Added support to pause/resume a Consumer using signals

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -6,8 +6,6 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Bernard\Event\EnvelopeEvent;
 use Bernard\Event\RejectEnvelopeEvent;
 
-declare(ticks=1);
-
 /**
  * @package Consumer
  */
@@ -40,6 +38,8 @@ class Consumer
      */
     public function consume(Queue $queue, array $options = [])
     {
+        declare(ticks=1);
+
         $this->bind();
 
         while ($this->tick($queue, $options)) {

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -63,16 +63,22 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
 
     public function testPauseResume()
     {
+        $service = new Fixtures\Service();
+
+        $this->router->add('ImportUsers', $service);
+
         $queue = new InMemoryQueue('queue');
         $queue->enqueue(new Envelope(new DefaultMessage('ImportUsers')));
 
         $this->consumer->pause();
 
-        $this->assertFalse($this->consumer->tick($queue));
+        $this->assertTrue($this->consumer->tick($queue));
+        $this->assertFalse($service->importUsers);
 
         $this->consumer->resume();
 
         $this->assertTrue($this->consumer->tick($queue));
+        $this->assertTrue($service->importUsers);
     }
 
     public function testMaxRuntime()

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -103,7 +103,7 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
 
         $this->consumer->tick($queue);
 
-        $this->assertTrue($service::$importUsers);
+        $this->assertTrue($service->importUsers);
     }
 
     public function testMaxMessages()
@@ -134,6 +134,6 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
 
         $this->consumer->tick($queue);
 
-        $this->assertTrue($service::$importUsers);
+        $this->assertTrue($service->importUsers);
     }
 }

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -61,6 +61,20 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse($this->consumer->tick($queue));
     }
 
+    public function testPauseResume()
+    {
+        $queue = new InMemoryQueue('queue');
+        $queue->enqueue(new Envelope(new DefaultMessage('ImportUsers')));
+
+        $this->consumer->pause();
+
+        $this->assertFalse($this->consumer->tick($queue));
+
+        $this->consumer->resume();
+
+        $this->assertTrue($this->consumer->tick($queue));
+    }
+
     public function testMaxRuntime()
     {
         $queue = new InMemoryQueue('queue');

--- a/tests/Fixtures/Service.php
+++ b/tests/Fixtures/Service.php
@@ -4,7 +4,7 @@ namespace Bernard\Tests\Fixtures;
 
 class Service
 {
-    public static $importUsers = false;
+    public $importUsers = false;
 
     public function failSendNewsletter()
     {
@@ -13,7 +13,7 @@ class Service
 
     public function importUsers()
     {
-        static::$importUsers = true;
+        $this->importUsers = true;
     }
 
     public function createFile()


### PR DESCRIPTION
Currently, the consumer can only be shutdown using signals. It's not possible to keep the consumer running but in a paused state (not consuming anything).

Resque has support for this and it's quite helpful while deploying your application. You can pause (SIGUSR2) consuming right before the deploy. It will continue working on existing jobs, but ignores new jobs. When you are done with the deploy, you can either unpause (SIGCONT) or shutdown (SIGTERM)  the consumer. In our situation, we let Supervisor automatically restart the consumers after they are shutdown.

I have also moved the declare(tickets=1) to the Consumer method. This way, you won't automatically declare it when you include the file, but only when actually consuming something.