### PR TITLE
Consumer > Added stop-after-last-message option

### DIFF
--- a/src/Command/ConsumeCommand.php
+++ b/src/Command/ConsumeCommand.php
@@ -37,6 +37,7 @@ class ConsumeCommand extends \Symfony\Component\Console\Command\Command
         $this
             ->addOption('max-runtime', null, InputOption::VALUE_OPTIONAL, 'Maximum time in seconds the consumer will run.', null)
             ->addOption('max-messages', null, InputOption::VALUE_OPTIONAL, 'Maximum number of messages that should be consumed.', null)
+            ->addOption('stop-after-last-message', null, InputOption::VALUE_NONE, 'Stop consumer after the last message is consumed.', null)
             ->addArgument('queue', InputArgument::REQUIRED, 'Name of queue that will be consumed.')
         ;
     }

--- a/src/Command/ConsumeCommand.php
+++ b/src/Command/ConsumeCommand.php
@@ -37,7 +37,7 @@ class ConsumeCommand extends \Symfony\Component\Console\Command\Command
         $this
             ->addOption('max-runtime', null, InputOption::VALUE_OPTIONAL, 'Maximum time in seconds the consumer will run.', null)
             ->addOption('max-messages', null, InputOption::VALUE_OPTIONAL, 'Maximum number of messages that should be consumed.', null)
-            ->addOption('stop-after-last-message', null, InputOption::VALUE_NONE, 'Stop consumer after the last message is consumed.', null)
+            ->addOption('stop-when-empty', null, InputOption::VALUE_NONE, 'Stop consumer when queue is empty.', null)
             ->addArgument('queue', InputArgument::REQUIRED, 'Name of queue that will be consumed.')
         ;
     }

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -19,7 +19,7 @@ class Consumer
     protected $options = [
         'max-runtime'  => PHP_INT_MAX,
         'max-messages' => null,
-        'stop-after-last-message' => false
+        'stop-when-empty' => false
     ];
 
     /**
@@ -75,7 +75,7 @@ class Consumer
         }
 
         if (!$envelope = $queue->dequeue()) {
-            return !$this->options['stop-after-last-message'];
+            return !$this->options['stop-when-empty'];
         }
 
 

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -19,6 +19,7 @@ class Consumer
     protected $options = [
         'max-runtime'  => PHP_INT_MAX,
         'max-messages' => null,
+        'stop-after-last-message' => false
     ];
 
     /**
@@ -74,7 +75,7 @@ class Consumer
         }
 
         if (!$envelope = $queue->dequeue()) {
-            return true;
+            return !$this->options['stop-after-last-message'];
         }
 
 

--- a/tests/Command/ConsumeCommandTest.php
+++ b/tests/Command/ConsumeCommandTest.php
@@ -26,12 +26,14 @@ class ConsumeCommandTest extends \PHPUnit_Framework_TestCase
         $this->consumer->expects($this->once())->method('consume')->with($this->equalTo($queue), $this->equalTo(array(
             'max-runtime' => 100,
             'max-messages' => 10,
+            'stop-when-empty' => true,
         )));
 
         $tester = new CommandTester($command);
         $tester->execute(array(
             '--max-runtime' => 100,
             '--max-messages' => 10,
+            '--stop-when-empty' => true,
             'queue' => 'send-newsletter',
         ));
     }

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -134,9 +134,9 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
         $queue->enqueue(new Envelope(new DefaultMessage('ImportUsers')));
         $queue->enqueue(new Envelope(new DefaultMessage('ImportUsers')));
 
-        $this->assertTrue($this->consumer->tick($queue, array('stop-after-last-message' => true)));
-        $this->assertTrue($this->consumer->tick($queue, array('stop-after-last-message' => true)));
-        $this->assertFalse($this->consumer->tick($queue, array('stop-after-last-message' => true)));
+        $this->assertTrue($this->consumer->tick($queue, array('stop-when-empty' => true)));
+        $this->assertTrue($this->consumer->tick($queue, array('stop-when-empty' => true)));
+        $this->assertFalse($this->consumer->tick($queue, array('stop-when-empty' => true)));
     }
 
     /**

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -126,6 +126,19 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue($this->consumer->tick($queue, array('max-messages' => 100)));
     }
 
+    public function testStopAfterLastMessage()
+    {
+        $this->router->add('ImportUsers', new Fixtures\Service);
+
+        $queue = new InMemoryQueue('send-newsletter');
+        $queue->enqueue(new Envelope(new DefaultMessage('ImportUsers')));
+        $queue->enqueue(new Envelope(new DefaultMessage('ImportUsers')));
+
+        $this->assertTrue($this->consumer->tick($queue, array('stop-after-last-message' => true)));
+        $this->assertTrue($this->consumer->tick($queue, array('stop-after-last-message' => true)));
+        $this->assertFalse($this->consumer->tick($queue, array('stop-after-last-message' => true)));
+    }
+
     /**
      * @group debug
      */


### PR DESCRIPTION
This PR allows you to start a consumer, process all messages, and automatically shutdown when the last message is processed.

Useful for testing purposes.