### PR TITLE
Add support for round robin queues to ConsumeCommand

### DIFF
--- a/src/Command/ConsumeCommand.php
+++ b/src/Command/ConsumeCommand.php
@@ -38,7 +38,7 @@ class ConsumeCommand extends \Symfony\Component\Console\Command\Command
             ->addOption('max-runtime', null, InputOption::VALUE_OPTIONAL, 'Maximum time in seconds the consumer will run.', null)
             ->addOption('max-messages', null, InputOption::VALUE_OPTIONAL, 'Maximum number of messages that should be consumed.', null)
             ->addOption('stop-when-empty', null, InputOption::VALUE_NONE, 'Stop consumer when queue is empty.', null)
-            ->addArgument('queue', InputArgument::REQUIRED, 'Names of one or more queues that will be consumed, separated by commas.')
+            ->addArgument('queue', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'Names of one or more queues that will be consumed.')
         ;
     }
 
@@ -53,15 +53,15 @@ class ConsumeCommand extends \Symfony\Component\Console\Command\Command
     }
 
     /**
-     * @param string $queue
+     * @param array $queue
      * @return Queue
      */
     protected function getQueue($queue)
     {
-        if (strpos($queue, ',') !== false) {
+        if (count($queue) > 1) {
             $queues = array_map([$this->queues, 'create'], explode(',', $queue));
             return new \Bernard\Queue\RoundRobinQueue($queues);
         }
-        return $this->queues->create($queue);
+        return $this->queues->create(array_shift($queue));
     }
 }

--- a/src/Command/ConsumeCommand.php
+++ b/src/Command/ConsumeCommand.php
@@ -54,15 +54,15 @@ class ConsumeCommand extends \Symfony\Component\Console\Command\Command
     }
 
     /**
-     * @param array $queue
+     * @param array|string $queue
      * @return Queue
      */
     protected function getQueue($queue)
     {
-        if (count($queue) > 1) {
-            $queues = array_map([$this->queues, 'create'], explode(',', $queue));
+        if (is_array($queue) {
+            $queues = array_map([$this->queues, 'create'], $queue);
             return new RoundRobinQueue($queues);
         }
-        return $this->queues->create(array_shift($queue));
+        return $this->queues->create($queue);
     }
 }

--- a/src/Command/ConsumeCommand.php
+++ b/src/Command/ConsumeCommand.php
@@ -3,6 +3,7 @@
 namespace Bernard\Command;
 
 use Bernard\Consumer;
+use Bernard\Queue\RoundRobinQueue;
 use Bernard\QueueFactory;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
@@ -60,7 +61,7 @@ class ConsumeCommand extends \Symfony\Component\Console\Command\Command
     {
         if (count($queue) > 1) {
             $queues = array_map([$this->queues, 'create'], explode(',', $queue));
-            return new \Bernard\Queue\RoundRobinQueue($queues);
+            return new RoundRobinQueue($queues);
         }
         return $this->queues->create(array_shift($queue));
     }

--- a/src/Command/ConsumeCommand.php
+++ b/src/Command/ConsumeCommand.php
@@ -59,7 +59,7 @@ class ConsumeCommand extends \Symfony\Component\Console\Command\Command
      */
     protected function getQueue($queue)
     {
-        if (is_array($queue) {
+        if (is_array($queue)) {
             $queues = array_map([$this->queues, 'create'], $queue);
             return new RoundRobinQueue($queues);
         }

--- a/tests/Command/ConsumeCommandTest.php
+++ b/tests/Command/ConsumeCommandTest.php
@@ -55,7 +55,7 @@ class ConsumeCommandTest extends \PHPUnit_Framework_TestCase
             '--max-runtime' => 100,
             '--max-messages' => 10,
             '--stop-when-empty' => true,
-            'queue' => 'queue-1,queue-2',
+            'queue' => ['queue-1', 'queue-2'],
         ));
     }
 }

--- a/tests/Command/ConsumeCommandTest.php
+++ b/tests/Command/ConsumeCommandTest.php
@@ -37,4 +37,25 @@ class ConsumeCommandTest extends \PHPUnit_Framework_TestCase
             'queue' => 'send-newsletter',
         ));
     }
+
+    public function testItConsumesRoundRobin()
+    {
+        $command = new ConsumeCommand($this->consumer, $this->queues);
+
+        $args = array(
+            'max-runtime' => 100,
+            'max-messages' => 10,
+            'stop-when-empty' => true,
+        );
+
+        $this->consumer->expects($this->once())->method('consume')->with($this->isInstanceOf('Bernard\Queue\RoundRobinQueue'), $args);
+
+        $tester = new CommandTester($command);
+        $tester->execute(array(
+            '--max-runtime' => 100,
+            '--max-messages' => 10,
+            '--stop-when-empty' => true,
+            'queue' => 'queue-1,queue-2',
+        ));
+    }
 }


### PR DESCRIPTION
This integrates the round robin queue support added for #181 via #188 into `ConsumeCommand`.

More specifically, with this change, `ConsumeCommand` will use the round robin strategy if its `queue` argument value contains one or more commas delimiting the names of multiple queues; otherwise, it will fall back to the current logic of assuming that the `queue` argument value references a single queue.

Note that the [test failures](https://travis-ci.org/bernardphp/bernard/jobs/91047388) currently reported by Travis for this PR are unrelated to its changes; see #195 for more information.