### PR TITLE
Fix round robin queue tests under PHP 7

### DIFF
--- a/tests/Queue/RoundRobinQueueTest.php
+++ b/tests/Queue/RoundRobinQueueTest.php
@@ -68,14 +68,10 @@ class RoundRobinQueueTest extends \PHPUnit_Framework_TestCase
 
     public function testClose()
     {
-        $builder = $this->getMockBuilder('Bernard\\Queue');
+        $builder = $this->getMockBuilder('Bernard\\Queue\\InMemoryQueue')->setMethods(['close']);
         $queues = [];
         for ($name = 1; $name <= 3; $name++) {
-            $queue = $builder->getMock();
-            $queue
-                ->expects($this->any())
-                ->method('__toString')
-                ->will($this->returnValue((string) $name));
+            $queue = $builder->setConstructorArgs([$name])->getMock();
             $queue
                 ->expects($this->once())
                 ->method('close');
@@ -110,20 +106,17 @@ class RoundRobinQueueTest extends \PHPUnit_Framework_TestCase
 
     public function testAcknowledgeWithRecognizedQueue()
     {
-        $builder = $this->getMockBuilder('Bernard\\Queue');
+        $builder = $this->getMockBuilder('Bernard\\Queue\\InMemoryQueue')->setMethods(['acknowledge']);
         $envelope = $this->getEnvelope('2');
 
         $queues = [
-            $queue_1 = $builder->getMock(),
-            $queue_2 = $builder->getMock(),
-            $queue_3 = $builder->getMock(),
+            $queue_1 = $builder->setConstructorArgs(['1'])->getMock(),
+            $queue_2 = $builder->setConstructorArgs(['2'])->getMock(),
+            $queue_3 = $builder->setConstructorArgs(['3'])->getMock(),
         ];
 
-        $queue_1->expects($this->any())->method('__toString')->will($this->returnValue('1'));
         $queue_1->expects($this->never())->method('acknowledge');
-        $queue_2->expects($this->any())->method('__toString')->will($this->returnValue('2'));
         $queue_2->expects($this->once())->method('acknowledge')->with($envelope);
-        $queue_3->expects($this->any())->method('__toString')->will($this->returnValue('3'));
         $queue_3->expects($this->never())->method('acknowledge');
 
         $round = new RoundRobinQueue($queues);


### PR DESCRIPTION
PR #193 modified the Travis configuration to disallow test failures under PHP 7. This revealed some test failures for `RoundRobinQueue`, which was recently added via PR #188, that are seemingly specific to PHP 7.

These test failures don't appear to be caused by a defect of the code under test, but seem likely to be due to a known regression in PHPUnit's mocking library, namely sebastianbergmann/phpunit-mock-objects#267.

This change is a work-around for this regression. It modifies the affected tests such that, instead of using full mock instances of `Queue` for the queues contained by `RoundRobinQueue`, they instead use partial mock instances of `InMemoryQueue` so as to use its implementation of `__toString()` and thus avoid the need to stub it. It's admittedly not ideal, but barring any significant changes to `InMemoryQueue`, it should allow the `RoundRobinQueue` test suite to pass and still remain accurate in the results it reports.