### PR TITLE
Use queue name when fetching queue instance instead of message name.

### DIFF
--- a/src/Envelope.php
+++ b/src/Envelope.php
@@ -43,6 +43,14 @@ class Envelope
     /**
      * @return string
      */
+    public function getQueue()
+    {
+        return $this->message->getQueue();
+    }
+
+    /**
+     * @return string
+     */
     public function getClass()
     {
         return $this->class;

--- a/src/Message.php
+++ b/src/Message.php
@@ -11,4 +11,9 @@ interface Message
      * @return string
      */
     public function getName();
+
+    /**
+     * @return string
+     */
+    public function getQueue();
 }

--- a/src/Queue/RoundRobinQueue.php
+++ b/src/Queue/RoundRobinQueue.php
@@ -123,7 +123,7 @@ class RoundRobinQueue implements Queue
     {
         $this->verifyEnvelope($envelope);
 
-        $this->queues[$envelope->getName()]->acknowledge($envelope);
+        $this->queues[$envelope->getQueue()]->acknowledge($envelope);
     }
 
     /**
@@ -184,7 +184,7 @@ class RoundRobinQueue implements Queue
      */
     protected function verifyEnvelope(Envelope $envelope)
     {
-        $queue = $envelope->getName();
+        $queue = $envelope->getQueue();
         if (isset($this->queues[$queue])) {
             return;
         }


### PR DESCRIPTION
This seems to fix issue #198 for me. By using the _getQueue_ method of a _Message_ instance I get the correct index name of the queue.