### PR TITLE
Added options array to queue create and message produce

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,18 @@ cache:
 
 services: mongodb
 
+matrix:
+   include:
+     - php: 5.6
+       env: SYMFONY_VERSION="2.3.*"
+     - php: 5.6
+       env: SYMFONY_VERSION="2.8.*"
+     - php: 5.6
+       env: SYMFONY_VERSION="3.0.*"
+
+before_install: if [[ "$SYMFONY_VERSION" != "" ]]; then composer require --no-update symfony/symfony:${SYMFONY_VERSION}; fi
+
+
 before_script:
   - tests/travis.sh
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "php": "~5.4|~7.0",
         "bernard/normalt": "~1.0",
         "symfony/event-dispatcher": "~2.3|~3.0",
-        "beberlei/assert": "~2.0"
+        "beberlei/assert": "~2.0",
+        "symfony/options-resolver": "~2.3|~3.0"
     },
     "require-dev" : {
         "psr/log": "~1.0",

--- a/doc/drivers.rst
+++ b/doc/drivers.rst
@@ -12,6 +12,8 @@ Several different types of drivers are supported. Currently these are available:
 * `MongoDB`_
 * `PhpAmqp / RabbitMQ`_
 
+You can pass option when you create a queue or push a message, see the driver for more specific info on which options can be passed.
+
 Redis Extension
 ---------------
 
@@ -205,6 +207,11 @@ correct service. An example of this:
         }
     }
 
+When pushing a message these are the allowed options:
+- timeout
+- delay
+- expires_in
+
 Amazon SQS
 ----------
 
@@ -325,6 +332,14 @@ something like this:
         }
     }
 
+When pushing a message these are the allowed options:
+- method
+- name
+- delay_seconds
+- header
+
+See the `official docs <https://cloud.google.com/appengine/docs/php/refdocs/classes/google.appengine.api.taskqueue.PushTask#method___construct>`_ for more info about the allowed options
+
 Pheanstalk
 ----------
 
@@ -349,6 +364,11 @@ Requires the installation of pda/pheanstalk. Add the following to your
     $pheanstalk = new Pheanstalk('localhost');
 
     $driver = new PheanstalkDriver($pheanstalk);
+
+When pushing a message these are the allowed options:
+- priority
+- delay
+- ttr
 
 MongoDB
 -------
@@ -392,6 +412,15 @@ To support message queries, the following index should also be created:
         'sentAt' => 1,
     ]);
 
+When creating a queue the allowed option is `upsert`
+
+When pushing a message these are the allowed options:
+- fsync
+- j
+- socketTimeoutMS
+- w
+- wTimeoutMS
+
 PhpAmqp / RabbitMQ
 ------------------
 
@@ -414,3 +443,11 @@ parameters.
         'my-exchange',
         ['content_type' => 'application/json', 'delivery_mode' => 2]
     );
+
+When creating a queue the allowed option is `routingkey`
+
+When pushing a message these are the allowed options:
+- routingkey
+- mandatory
+- immediate
+- ticket

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -167,7 +167,7 @@ class Consumer
     protected function bind()
     {
         pcntl_signal(SIGTERM, [$this, 'shutdown']);
-        pcntl_signal(SIGINT,  [$this, 'shutdown']);
+        pcntl_signal(SIGINT, [$this, 'shutdown']);
         pcntl_signal(SIGQUIT, [$this, 'shutdown']);
         pcntl_signal(SIGUSR2, [$this, 'pause']);
         pcntl_signal(SIGCONT, [$this, 'resume']);

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -18,8 +18,11 @@ interface Driver
      * Create a queue.
      *
      * @param string $queueName
+     * @param array  $options
+     *
+     * @return
      */
-    public function createQueue($queueName);
+    public function createQueue($queueName, array $options = []);
 
     /**
      * Count the number of messages in queue. This can be a approximately number.
@@ -33,8 +36,11 @@ interface Driver
      *
      * @param string $queueName
      * @param string $message
+     * @param array  $options
+     *
+     * @return
      */
-    public function pushMessage($queueName, $message);
+    public function pushMessage($queueName, $message, array $options = []);
 
     /**
      * Remove the next message in line. And if no message is available

--- a/src/Driver/AbstractDriver.php
+++ b/src/Driver/AbstractDriver.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Bernard\Driver;
+
+use Bernard\Driver;
+use Symfony\Component\OptionsResolver\Exception\InvalidOptionsException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
+
+abstract class AbstractDriver implements Driver
+{
+    /**
+     * Validate queue options
+     *
+     * @param array $options
+     *
+     * @return array
+     * @throws InvalidOptionsException
+     */
+    final public function validateQueueOptions(array $options)
+    {
+        $resolver = new OptionsResolver();
+        $this->configureQueueOptions($resolver);
+
+        return $resolver->resolve($options);
+    }
+
+    /**
+     * Validate queue options
+     *
+     * @param array $options
+     *
+     * @return array
+     * @throws InvalidOptionsException
+     */
+    final public function validatePushOptions(array $options)
+    {
+        $resolver = new OptionsResolver();
+        $this->configurePushOptions($resolver);
+
+        return $resolver->resolve($options);
+    }
+
+    /**
+     * Configure createQueue options
+     *
+     * @param OptionsResolver $resolver
+     */
+    public function configureQueueOptions(OptionsResolver $resolver)
+    {
+    }
+
+    /**
+     * Configure push message options
+     *
+     * @param OptionsResolver $resolver
+     */
+    public function configurePushOptions(OptionsResolver $resolver)
+    {
+    }
+}

--- a/src/Driver/AbstractPrefetchDriver.php
+++ b/src/Driver/AbstractPrefetchDriver.php
@@ -8,7 +8,7 @@ namespace Bernard\Driver;
  *
  * @package Bernard
  */
-abstract class AbstractPrefetchDriver implements \Bernard\Driver
+abstract class AbstractPrefetchDriver extends AbstractDriver
 {
     protected $prefetch;
     protected $cache;

--- a/src/Driver/DoctrineDriver.php
+++ b/src/Driver/DoctrineDriver.php
@@ -35,7 +35,7 @@ class DoctrineDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function createQueue($queueName)
+    public function createQueue($queueName, array $options = [])
     {
         try {
             $this->connection->insert('bernard_queues', ['name' => $queueName]);
@@ -61,7 +61,7 @@ class DoctrineDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
         $types = ['string', 'string', 'datetime'];
         $data = [

--- a/src/Driver/FlatFileDriver.php
+++ b/src/Driver/FlatFileDriver.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace Bernard\Driver;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Flat file driver to provide a simple job queue without any
@@ -8,7 +9,7 @@ namespace Bernard\Driver;
  *
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  */
-class FlatFileDriver implements \Bernard\Driver
+class FlatFileDriver extends AbstractDriver
 {
     private $baseDirectory;
 
@@ -43,7 +44,7 @@ class FlatFileDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function createQueue($queueName)
+    public function createQueue($queueName, array $options = [])
     {
         $queueDir = $this->getQueueDirectory($queueName);
 
@@ -69,7 +70,7 @@ class FlatFileDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
         $queueDir = $this->getQueueDirectory($queueName);
 

--- a/src/Driver/PheanstalkDriver.php
+++ b/src/Driver/PheanstalkDriver.php
@@ -3,13 +3,14 @@
 namespace Bernard\Driver;
 
 use Pheanstalk\PheanstalkInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Implements a Driver for use with https://github.com/pda/pheanstalk
  *
  * @package Bernard
  */
-class PheanstalkDriver implements \Bernard\Driver
+class PheanstalkDriver extends AbstractDriver
 {
     protected $pheanstalk;
 
@@ -32,7 +33,7 @@ class PheanstalkDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function createQueue($queueName)
+    public function createQueue($queueName, array $options = [])
     {
     }
 
@@ -49,9 +50,17 @@ class PheanstalkDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
-        $this->pheanstalk->putInTube($queueName, $message);
+        $options = $this->validatePushOptions($options);
+
+        $this->pheanstalk->putInTube(
+            $queueName,
+            $message,
+            $options['priority'],
+            $options['delay'],
+            $options['ttr']
+        );
     }
 
     /**
@@ -98,5 +107,17 @@ class PheanstalkDriver implements \Bernard\Driver
             ->stats()
             ->getArrayCopy()
         ;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function configurePushOptions(OptionsResolver $resolver)
+    {
+        $resolver->setDefaults(array(
+            'priority' => PheanstalkInterface::DEFAULT_PRIORITY,
+            'delay' => PheanstalkInterface::DEFAULT_DELAY,
+            'ttr' => PheanstalkInterface::DEFAULT_TTR,
+        ));
     }
 }

--- a/src/Driver/PhpRedisDriver.php
+++ b/src/Driver/PhpRedisDriver.php
@@ -9,7 +9,7 @@ use Redis;
  *
  * @package Bernard
  */
-class PhpRedisDriver implements \Bernard\Driver
+class PhpRedisDriver extends AbstractDriver
 {
     protected $redis;
 
@@ -32,7 +32,7 @@ class PhpRedisDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function createQueue($queueName)
+    public function createQueue($queueName, array $options = [])
     {
         $this->redis->sAdd('queues', $queueName);
     }
@@ -48,7 +48,7 @@ class PhpRedisDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
         $this->redis->rpush($this->resolveKey($queueName), $message);
     }

--- a/src/Driver/SqsDriver.php
+++ b/src/Driver/SqsDriver.php
@@ -54,7 +54,7 @@ class SqsDriver extends AbstractPrefetchDriver
     /**
      * {@inheritdoc}
      */
-    public function createQueue($queueName)
+    public function createQueue($queueName, array $options = [])
     {
     }
 
@@ -80,7 +80,7 @@ class SqsDriver extends AbstractPrefetchDriver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
         $queueUrl = $this->resolveUrl($queueName);
 

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -26,13 +26,15 @@ class Producer
     /**
      * @param Message     $message
      * @param string|null $queueName
+     * @param array       $options
      */
-    public function produce(Message $message, $queueName = null)
+    public function produce(Message $message, $queueName = null, array $options = [])
     {
         $queueName = $queueName ?: Util::guessQueue($message);
+        $envelope = new Envelope($message);
 
-        $queue = $this->queues->create($queueName);
-        $queue->enqueue($envelope = new Envelope($message));
+        $queue = $this->queues->create($queueName, $options);
+        $queue->enqueue($envelope, $options);
 
         $this->dispatcher->dispatch('bernard.produce', new EnvelopeEvent($envelope, $queue));
     }

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -9,8 +9,11 @@ interface Queue extends \Countable
 {
     /**
      * @param Envelope $envelope
+     * @param array    $options
+     *
+     * @return
      */
-    public function enqueue(Envelope $envelope);
+    public function enqueue(Envelope $envelope, array $options = []);
 
     /**
      * @return Envelope

--- a/src/Queue/InMemoryQueue.php
+++ b/src/Queue/InMemoryQueue.php
@@ -37,7 +37,7 @@ class InMemoryQueue extends AbstractQueue
     /**
      * {@inheritdoc}
      */
-    public function enqueue(Envelope $envelope)
+    public function enqueue(Envelope $envelope, array $options = [])
     {
         $this->errorIfClosed();
 

--- a/src/Queue/PersistentQueue.php
+++ b/src/Queue/PersistentQueue.php
@@ -14,19 +14,22 @@ class PersistentQueue extends AbstractQueue
     protected $driver;
     protected $serializer;
     protected $receipts;
+    protected $options;
 
     /**
      * @param string     $name
      * @param Driver     $driver
      * @param Serializer $serializer
+     * @param array      $options
      */
-    public function __construct($name, Driver $driver, Serializer $serializer)
+    public function __construct($name, Driver $driver, Serializer $serializer, array $options = [])
     {
         parent::__construct($name);
 
         $this->driver = $driver;
         $this->serializer = $serializer;
         $this->receipts = new \SplObjectStorage();
+        $this->options = $options;
 
         $this->register();
     }
@@ -38,7 +41,7 @@ class PersistentQueue extends AbstractQueue
     {
         $this->errorIfClosed();
 
-        $this->driver->createQueue($this->name);
+        $this->driver->createQueue($this->name, $this->options);
     }
 
     /**
@@ -64,11 +67,11 @@ class PersistentQueue extends AbstractQueue
     /**
      * {@inheritdoc}
      */
-    public function enqueue(Envelope $envelope)
+    public function enqueue(Envelope $envelope, array $options = [])
     {
         $this->errorIfClosed();
 
-        $this->driver->pushMessage($this->name, $this->serializer->serialize($envelope));
+        $this->driver->pushMessage($this->name, $this->serializer->serialize($envelope), $options);
     }
 
     /**

--- a/src/Queue/RoundRobinQueue.php
+++ b/src/Queue/RoundRobinQueue.php
@@ -40,11 +40,11 @@ class RoundRobinQueue implements Queue
     /**
      * {@inheritdoc}
      */
-    public function enqueue(Envelope $envelope)
+    public function enqueue(Envelope $envelope, array $options = [])
     {
         $this->verifyEnvelope($envelope);
 
-        $this->queues[$envelope->getName()]->enqueue($envelope);
+        $this->queues[$envelope->getName()]->enqueue($envelope, $options);
     }
 
     /**

--- a/src/QueueFactory.php
+++ b/src/QueueFactory.php
@@ -12,10 +12,11 @@ interface QueueFactory extends \Countable
 {
     /**
      * @param string $queueName
+     * @param array  $options
      *
      * @return Queue
      */
-    public function create($queueName);
+    public function create($queueName, array $options = []);
 
     /**
      * @return Queue[]

--- a/src/QueueFactory/InMemoryFactory.php
+++ b/src/QueueFactory/InMemoryFactory.php
@@ -17,7 +17,7 @@ class InMemoryFactory implements \Bernard\QueueFactory
     /**
      * {@inheritdoc}
      */
-    public function create($queueName)
+    public function create($queueName, array $options = [])
     {
         if (!$this->exists($queueName)) {
             $this->queues[$queueName] = new InMemoryQueue($queueName);

--- a/src/QueueFactory/PersistentFactory.php
+++ b/src/QueueFactory/PersistentFactory.php
@@ -32,13 +32,13 @@ class PersistentFactory implements \Bernard\QueueFactory
     /**
      * {@inheritdoc}
      */
-    public function create($queueName)
+    public function create($queueName, array $options = [])
     {
         if (isset($this->queues[$queueName])) {
             return $this->queues[$queueName];
         }
 
-        $queue = new PersistentQueue($queueName, $this->driver, $this->serializer);
+        $queue = new PersistentQueue($queueName, $this->driver, $this->serializer, $options);
 
         return $this->queues[$queueName] = $queue;
     }

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -4,6 +4,9 @@ if [ $TRAVIS_PHP_VERSION != "hhvm" ] && [ $TRAVIS_PHP_VERSION != "7.0" ]; then
 	pyrus install pecl/redis;
 	pyrus build pecl/redis;
 	echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
+
+	#Add mongo extension
+	echo "extension = mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 fi
 
 if [ $TRAVIS_PHP_VERSION = "hhvm" ]; then


### PR DESCRIPTION
Added options array to queue create and message send/push so we can pass options to the specific methods of each driver.

I've added this to fix #205, but I will expand it usage of the options so you can use all options of each driver method (queue create params and message push params)

I will create a seperate PR to add the docs for this and one for the usage of all params (for each specifc driver)

TODO:
- [x] Check if all option definitions are ok
- [x] Fix travis-ci build config so we test against symfony 2.3 and 3.0 (options-resolver)
- [x] Add BC layer to each configure*Options method (to support 2.3 and 3.0)
