### PR TITLE
Stop on error option for the consumer

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -20,7 +20,8 @@ class Consumer
     protected $options = [
         'max-runtime'  => PHP_INT_MAX,
         'max-messages' => null,
-        'stop-when-empty' => false
+        'stop-when-empty' => false,
+        'stop-on-error' => false,
     ];
 
     /**
@@ -140,6 +141,10 @@ class Consumer
             //
             // Emit an event to let others log that exception
             $this->dispatcher->dispatch('bernard.reject', new RejectEnvelopeEvent($envelope, $queue, $e));
+
+            if ($this->options['stop-on-error']) {
+                throw $e;
+            }
         }
     }
 

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -150,6 +150,21 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException \Bernard\Exception\ReceiverNotFoundException
+     */
+    public function testStopOnError()
+    {
+        $this->router->add('ImportUsers', new Fixtures\Service);
+
+        $queue = new InMemoryQueue('send-newsletter');
+        $queue->enqueue(new Envelope(new DefaultMessage('DifferentMessageKey')));
+
+        $this->consumer->tick($queue, array('stop-on-error' => true));
+
+        $this->assertEquals(1, $queue->count());
+    }
+
+    /**
      * @group debug
      */
     public function testEnvelopeWillBeInvoked()


### PR DESCRIPTION
This option will allow to stop the consumer on error, usefull in some cases. Default the consumer won't stop and only send the event