### PR TITLE
Missing stop-on-error option in consumer command

### DIFF
--- a/src/Command/ConsumeCommand.php
+++ b/src/Command/ConsumeCommand.php
@@ -39,6 +39,7 @@ class ConsumeCommand extends \Symfony\Component\Console\Command\Command
             ->addOption('max-runtime', null, InputOption::VALUE_OPTIONAL, 'Maximum time in seconds the consumer will run.', null)
             ->addOption('max-messages', null, InputOption::VALUE_OPTIONAL, 'Maximum number of messages that should be consumed.', null)
             ->addOption('stop-when-empty', null, InputOption::VALUE_NONE, 'Stop consumer when queue is empty.', null)
+            ->addOption('stop-on-error', null, InputOption::VALUE_NONE, 'Stop consumer when an error occurs.', null)
             ->addArgument('queue', InputArgument::REQUIRED | InputArgument::IS_ARRAY, 'Names of one or more queues that will be consumed.')
         ;
     }

--- a/tests/Command/ConsumeCommandTest.php
+++ b/tests/Command/ConsumeCommandTest.php
@@ -27,6 +27,7 @@ class ConsumeCommandTest extends \PHPUnit_Framework_TestCase
             'max-runtime' => 100,
             'max-messages' => 10,
             'stop-when-empty' => true,
+            'stop-on-error' => false,
         )));
 
         $tester = new CommandTester($command);
@@ -34,6 +35,7 @@ class ConsumeCommandTest extends \PHPUnit_Framework_TestCase
             '--max-runtime' => 100,
             '--max-messages' => 10,
             '--stop-when-empty' => true,
+            '--stop-on-error' => false,
             'queue' => 'send-newsletter',
         ));
     }
@@ -46,6 +48,7 @@ class ConsumeCommandTest extends \PHPUnit_Framework_TestCase
             'max-runtime' => 100,
             'max-messages' => 10,
             'stop-when-empty' => true,
+            'stop-on-error' => false,
         );
 
         $this->consumer->expects($this->once())->method('consume')->with($this->isInstanceOf('Bernard\Queue\RoundRobinQueue'), $args);
@@ -55,6 +58,7 @@ class ConsumeCommandTest extends \PHPUnit_Framework_TestCase
             '--max-runtime' => 100,
             '--max-messages' => 10,
             '--stop-when-empty' => true,
+            '--stop-on-error' => false,
             'queue' => ['queue-1', 'queue-2'],
         ));
     }


### PR DESCRIPTION
Added the missing consumer command option which was added in #208 