### PR TITLE
Docs rewrite

### DIFF
--- a/doc/consuming.rst
+++ b/doc/consuming.rst
@@ -14,31 +14,31 @@ object should handle which messages, you are required to register them first.
 
     <?php
 
-    use Bernard\ServiceResolver\ObjectResolver;
+    use Bernard\Router\SimpleRouter;
     use Bernard\Consumer;
 
     // .. create driver and a queuefactory
     // NewsletterMessageHandler is a pseudo service object that responds to
     // sendNewsletter.
 
-    $serviceResolver = new ObjectResolver;
-    $serviceResolver->register('SendNewsletter', new NewsletterMessageHandler);
+    $router = new SimpleRouter();
+    $router->add('SendNewsletter', new NewsletterMessageHandler);
 
-    // Bernard also comes with a service resolver for Pimple (Silex) which allows you
+    // Bernard also comes with a router for Pimple (Silex) which allows you
     // to use service ids and have your service object lazy loader.
     //
-    // $serviceResolver = new \Bernard\Pimple\PimpleAwareResolver($pimple);
-    // $serviceResolver->register('SendNewsletter', 'my.service.id');
+    // $router = new \Bernard\Router\PimpleAwareRouter($pimple);
+    // $router->add('SendNewsletter', 'my.service.id');
     //
     // Symfony DependencyInjection component is also supported.
     //
-    // $serviceResolver = new \Bernard\Symfony\ContainerAwareServiceResolver($container);
-    // $serviceResolver->register('SendNewsletter', 'my.service.id');
+    // $router = new \Bernard\Router\ContainerAwareRouter($container);
+    // $router->add('SendNewsletter', 'my.service.id');
 
     // Create a Consumer and start the loop. The second argument is optional and is an array
     // of options. Currently only ``max-runtime`` is supported which specifies the max runtime
     // in seconds.
-    $consumer = new Consumer($serviceResolver);
+    $consumer = new Consumer($router, $eventDispatcher);
     $consumer->consume($queueFactory->create('send-newsletter'), array(
         'max-runtime' => 900,
     ));
@@ -53,7 +53,7 @@ component.
 
     <?php
 
-    use Bernard\Symfony\Command\ConsumeCommand;
+    use Bernard\Command\ConsumeCommand;
 
     // create $console application
     $console->add(new ConsumeCommand($consumer, $queueFactory));
@@ -64,7 +64,7 @@ a newsletter, it would look like this.
 
 .. code-block:: bash
 
-    $ /path/to/console bernard:consume 'send-newsletter'
+    $ /path/to/console bernard:consume send-newsletter
 
 
 Internals

--- a/doc/drivers.rst
+++ b/doc/drivers.rst
@@ -3,67 +3,83 @@ Drivers
 
 Several different types of drivers are supported. Currently these are available:
 
+* `Google AppEngine`_
+* `Doctrine DBAL`_
+* `Flatfile`_
+* `IronMQ`_
+* `MongoDB`_
+* `Pheanstalk`_
+* `PhpAmqp / RabbitMQ`_
 * `Redis Extension`_
 * `Predis`_
-* `Doctrine DBAL`_
-* `IronMQ`_
 * `Amazon SQS`_
-* `Google AppEngine`_
-* `MongoDB`_
-* `PhpAmqp / RabbitMQ`_
 
-Redis Extension
----------------
+Google AppEngine
+----------------
 
-Requires the installation of the pecl extension. You can add the following to
-your ``composer.json`` file, to make sure it is installed:
+The Google AppEngine has support for PHP and PushQueue just as IronMQ. The AppEngine driver for Bernard is a minimal driver
+that uses its TaskQueue to push messages.
+Visit the `official docs <https://developers.google.com/appengine/docs/php/taskqueue/overview-push>`_ to get more information on the
+usage of the AppEngine api.
 
-.. code-block:: json
+.. important::
 
-    {
-        "require" : {
-            "ext-redis" : "~2.2"
-        }
-    }
+    This driver only works on AppEngine or with its development server as it
+    needs access to its SDK. It must also be autoloadable. If it is in the
+    include path you can use ``"config" : { "use-include-path" : true } }`` in
+    Composer.
 
-.. code-block:: php
-
-    <?php
-
-    use Bernard\Driver\PhpRedisDriver;
-
-    $redis = new Redis();
-    $redis->connect('127.0.0.1', 6379);
-    $redis->setOption(Redis::OPT_PREFIX, 'bernard:');
-
-    $driver = new PhpRedisDriver($redis);
-
-Predis
-------
-
-Requires the installation of predis. Add the following to your
-``composer.json`` file for this:
-
-.. code-block:: json
-
-    {
-        "require" : {
-            "predis/predis" : "~0.8"
-        }
-    }
+The driver takes a list of queue names and mappings to an endpoint. This is
+because queues are created at runtime and their endpoints are not
+preconfigured.
 
 .. code-block:: php
 
     <?php
 
-    use Bernard\Driver\PredisDriver;
-    use Predis\Client;
+    use Bernard\Driver\AppEngineDriver;
 
-    $predis = new Client('tcp://localhost', array(
-        'prefix' => 'bernard:',
+    $driver = new AppEngineDriver(array(
+        'queue-name' => '/url_endpoint',
     ));
 
-    $driver = new PredisDriver($predis);
+To consume messages, you need to create an url endpoint matching the one given
+to the drivers constructor. For the actual dispatching of messages, you can do
+something like this:
+
+.. code-block:: php
+
+    <?php
+
+    namespace Acme\Controller;
+
+    use Bernard\Consumer
+    use Bernard\Serializer;
+    use Bernard\QueueFactory;
+    use Symfony\Component\HttpFoundation\Request;
+
+    class QueueController
+    {
+        protected $consumer;
+        protected $queues;
+        protected $serializer;
+
+        public function __construct(Consumer $consumer, QueueFactory $queues, Serializer $serializer)
+        {
+            $this->consumer = $consumer;
+            $this->queues = $queues;
+            $this->serializer = $serializer;
+        }
+
+        public function queueAction(Request $request)
+        {
+            $envelope = $this->serializer->deserialize($request->getContent());
+
+            // This will invoke the right service and middleware, and lastly it will acknowledge
+            // the message.
+            $this->consumer->invoke($envelope, $this->queues->create($envelope->getMessage()->getQueue()));
+        }
+    }
 
 Doctrine DBAL
 -------------
@@ -124,6 +140,19 @@ And here is the setup of the driver for doctrine dbal:
 
 
     $driver = new DoctrineDriver($connection);
+
+Flatfile
+--------
+
+The flat file driver provides a simple job queue without any database
+
+.. code-block:: php
+
+    <?php
+
+    use Bernard\Driver\FlatFileDriver;
+
+    $driver = new FlatFileDriver('/dir/to/store/messages');
 
 IronMQ
 ------
@@ -205,6 +234,149 @@ correct service. An example of this:
         }
     }
 
+MongoDB
+-------
+
+The MongoDB driver requires the `mongo PECL extension <http://pecl.php.net/package/mongo>`_.
+On platforms where the PECL extension is unavailable, such as HHVM,
+`mongofill <https://github.com/mongofill/mongofill>`_ may be used instead.
+
+The driver should be constructed with two MongoCollection objects, which
+corresponding to the queue and message collections, respectively.
+
+.. code-block:: php
+
+    <?php
+
+    $mongoClient = new \MongoClient();
+    $driver = new \Bernard\Driver\MongoDBDriver(
+        $mongoClient->selectCollection('bernardDatabase', 'queues'),
+        $mongoClient->selectCollection('bernardDatabase', 'messages'),
+    );
+
+.. note::
+
+    If you are using Doctrine MongoDB or the ODM, you can access the
+    MongoCollection objects through the ``getMongoCollection()`` method on the
+    ``Doctrine\MongoDB\Collection`` wrapper class, which in turn may be
+    retrieved from a ``Doctrine\MongoDB\Database`` wrapper or DocumentManager
+    directly.
+
+To support message queries, the following index should also be created:
+
+.. code-block:: php
+
+    <?php
+
+    $mongoClient = new \MongoClient();
+    $collection = $mongoClient->selectCollection('bernardDatabase', 'messages');
+    $collection->createIndex([
+        'queue' => 1,
+        'visible' => 1,
+        'sentAt' => 1,
+    ]);
+
+Pheanstalk
+----------
+
+Requires the installation of pda/pheanstalk. Add the following to your
+``composer.json`` file for this:
+
+.. code-block:: json
+
+    {
+        "require" : {
+            "pda/pheanstalk" : "~3.0"
+        }
+    }
+
+.. code-block:: php
+
+    <?php
+
+    use Bernard\Driver\PheanstalkDriver;
+    use Pheanstalk\Pheanstalk;
+
+    $pheanstalk = new Pheanstalk('localhost');
+
+    $driver = new PheanstalkDriver($pheanstalk);
+
+PhpAmqp / RabbitMQ
+------------------
+
+The RabbitMQ driver uses the `php-amqp library by php-amqplib <https://github.com/php-amqplib/php-amqplib>`_.
+
+The driver should be constructed with an ``AMQPStreamConnection`` object, an exchange name and optionally the default message
+parameters.
+
+.. code-block:: php
+
+    <?php
+
+    $connection = new \PhpAmqpLib\Connection\AMQPStreamConnection('localhost', 5672, 'foo', 'bar');
+
+    $driver = new \Bernard\Driver\PhpAmqpDriver($connection, 'my-exchange');
+
+    // Or with default message params
+    $driver = new \Bernard\Driver\PhpAmqpDriver(
+        $connection,
+        'my-exchange',
+        ['content_type' => 'application/json', 'delivery_mode' => 2]
+    );
+
+Redis Extension
+---------------
+
+Requires the installation of the pecl extension. You can add the following to
+your ``composer.json`` file, to make sure it is installed:
+
+.. code-block:: json
+
+    {
+        "require" : {
+            "ext-redis" : "~2.2"
+        }
+    }
+
+.. code-block:: php
+
+    <?php
+
+    use Bernard\Driver\PhpRedisDriver;
+
+    $redis = new Redis();
+    $redis->connect('127.0.0.1', 6379);
+    $redis->setOption(Redis::OPT_PREFIX, 'bernard:');
+
+    $driver = new PhpRedisDriver($redis);
+
+Predis
+------
+
+Requires the installation of predis. Add the following to your
+``composer.json`` file for this:
+
+.. code-block:: json
+
+    {
+        "require" : {
+            "predis/predis" : "~0.8"
+        }
+    }
+
+.. code-block:: php
+
+    <?php
+
+    use Bernard\Driver\PredisDriver;
+    use Predis\Client;
+
+    $predis = new Client('tcp://localhost', array(
+        'prefix' => 'bernard:',
+    ));
+
+    $driver = new PredisDriver($predis);
+
 Amazon SQS
 ----------
 
@@ -257,160 +429,3 @@ require a HTTP request to amazon to be resolved.
     $driver = new SqsDriver($connection, array(
         'queue-name' => 'queue-url',
     ));
-
-Google AppEngine
-----------------
-
-The Google AppEngine has support for PHP and PushQueue just as IronMQ. The
-AppEngine driver for Bernard is a minimal driver that uses its TaskQueue to
-push messages. There is a lot about how this works in
-`their documentation <https://developers.google.com/appengine/docs/php/taskqueue/overview-push>`_.
-
-.. important::
-
-    This driver only works on AppEngine or with its development server as it
-    needs access to its SDK. It must also be autoloadable. If it is in the
-    include path you can use ``"config" : { "use-include-path" : true } }`` in
-    Composer.
-
-The driver takes a list of queue names and mappings to an endpoint. This is
-because queues are created at runtime and their endpoints are not
-preconfigured.
-
-.. code-block:: php
-
-    <?php
-
-    use Bernard\Driver\AppEngineDriver;
-
-    $driver = new AppEngineDriver(array(
-        'queue-name' => '/url_endpoint',
-    ));
-
-To consume messages, you need to create an url endpoint matching the one given
-to the drivers constructor. For the actual dispatching of messages, you can do
-something like this:
-
-.. code-block:: php
-
-    <?php
-
-    namespace Acme\Controller;
-
-    use Bernard\Consumer
-    use Bernard\Serializer;
-    use Bernard\QueueFactory;
-    use Symfony\Component\HttpFoundation\Request;
-
-    class QueueController
-    {
-        protected $consumer;
-        protected $queues;
-        protected $serializer;
-
-        public function __construct(Consumer $consumer, QueueFactory $queues, Serializer $serializer)
-        {
-            $this->consumer = $consumer;
-            $this->queues = $queues;
-            $this->serializer = $serializer;
-        }
-
-        public function queueAction(Request $request)
-        {
-            $envelope = $this->serializer->deserialize($request->getContent());
-
-            // This will invoke the right service and middleware, and lastly it will acknowledge
-            // the message.
-            $this->consumer->invoke($envelope, $this->queues->create($envelope->getMessage()->getQueue()));
-        }
-    }
-
-Pheanstalk
-----------
-
-Requires the installation of pda/pheanstalk. Add the following to your
-``composer.json`` file for this:
-
-.. code-block:: json
-
-    {
-        "require" : {
-            "pda/pheanstalk" : "~3.0"
-        }
-    }
-
-.. code-block:: php
-
-    <?php
-
-    use Bernard\Driver\PheanstalkDriver;
-    use Pheanstalk\Pheanstalk;
-
-    $pheanstalk = new Pheanstalk('localhost');
-
-    $driver = new PheanstalkDriver($pheanstalk);
-
-MongoDB
--------
-
-The MongoDB driver requires the `mongo PECL extension <http://pecl.php.net/package/mongo>`_.
-On platforms where the PECL extension is unavailable, such as HHVM,
-`mongofill <https://github.com/mongofill/mongofill>`_ may be used instead.
-
-The driver should be constructed with two MongoCollection objects, which
-corresponding to the queue and message collections, respectively.
-
-.. code-block:: php
-
-    <?php
-
-    $mongoClient = new \MongoClient();
-    $driver = new \Bernard\Driver\MongoDBDriver(
-        $mongoClient->selectCollection('bernardDatabase', 'queues'),
-        $mongoClient->selectCollection('bernardDatabase', 'messages'),
-    );
-
-.. note::
-
-    If you are using Doctrine MongoDB or the ODM, you can access the
-    MongoCollection objects through the ``getMongoCollection()`` method on the
-    ``Doctrine\MongoDB\Collection`` wrapper class, which in turn may be
-    retrieved from a ``Doctrine\MongoDB\Database`` wrapper or DocumentManager
-    directly.
-
-To support message queries, the following index should also be created:
-
-.. code-block:: php
-
-    <?php
-
-    $mongoClient = new \MongoClient();
-    $collection = $mongoClient->selectCollection('bernardDatabase', 'messages');
-    $collection->createIndex([
-        'queue' => 1,
-        'visible' => 1,
-        'sentAt' => 1,
-    ]);
-
-PhpAmqp / RabbitMQ
-------------------
-
-The RabbitMQ driver leans on the php-amqp library by php-amqplib.
-
-The driver should be constructed with an ``AMQPStreamConnection`` object, an exchange name and optionally the default message
-parameters.
-
-.. code-block:: php
-
-    <?php
-
-    $connection = new \PhpAmqpLib\Connection\AMQPStreamConnection('localhost', 5672, 'foo', 'bar');
-
-    $driver = new \Bernard\Driver\PhpAmqpDriver($connection, 'my-exchange');
-
-    // Or with default message params
-    $driver = new \Bernard\Driver\PhpAmqpDriver(
-        $connection,
-        'my-exchange',
-        ['content_type' => 'application/json', 'delivery_mode' => 2]
-    );

--- a/doc/frameworks.rst
+++ b/doc/frameworks.rst
@@ -4,6 +4,10 @@ Framework Integration
 To make it easier to get started and have it "just work" with sending messages,
 a number of integrations have been created.
 
+Symfony
+-------
+
+The `bernard/bernard-bundle <https://github.com/bernardphp/BernardBundle>`_ integrates Bernard with a Symfony application.
 
 Silex
 -----

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,7 +4,7 @@ Getting Started
 Installation
 ------------
 
-The easiest way to install Bernard is using `Composer <http://getcomposer.org>`_.
+The recommended way to install Bernard is using `Composer <http://getcomposer.org>`_.
 If your projects do not already use this, it is highly recommended to start
 using it.
 
@@ -12,10 +12,10 @@ To install Bernard, run:
 
 .. code-block:: bash
 
-    $ composer require bernard/bernard:0.6.0
+    $ composer require bernard/bernard
 
-Then look at what kind of drivers and serializers there is available and install
-the ones you like before you are going to use Bernard.
+Then look at what kind of drivers and serializers are available and install
+the ones you need before you are going to use Bernard.
 
 Examples
 --------
@@ -35,57 +35,13 @@ the exception is caused by ``rand()`` always returning 7.
 
 This directory is a good source for setting stuff up and can be used as a go to guide.
 
-Producing Messages
-------------------
-
-Any message sent to Bernard must be an instance of ``Bernard\Message``,
-which has a ``getName`` and ``getQueue`` method. ``getName`` is used when working on
-messages and identifies the worker service that should work on it.
-
-A message is given to a producer that sends the message to the right queue.
-It is also possible to get the queue directly from the queue factory and push
-the message there. But remember to wrap the message in an ``Envelope`` object.
-The easiest way is to give it to the producer, as the queue name
-is taken from the message object.
-
-To make it easier to send messages and not require every type to be implemented
-in a separate class, a ``Bernard\Message\DefaultMessage`` is provided. It can hold
-any number of properties and only needs a name for the message. The queue name
-is then generated from that. When generating the queue name it will insert a "_"
-before any uppercase letter and then lowercase the name.
-
-.. code-block:: php
-
-    <?php
-
-    use Bernard\Message\DefaultMessage;
-    use Bernard\Producer;
-    use Bernard\QueueFactory\PersistentFactory;
-    use Bernard\Serializer\NaiveSerializer;
-
-    // .. create $driver
-    $factory = new PersistentFactory($driver, new NaiveSerializer());
-    $producer = new Producer($factory);
-
-    $message = new DefaultMessage("SendNewsletter", array(
-        'newsletterId' => 12,
-    ));
-
-    $producer->produce($message);
-
-In Memory Queues
-~~~~~~~~~~~~~~~~
-
-Bernard comes with an implementation for ``SplQueue`` which is completly in memory.
-It is useful for development and/or testing, when you don't necessarily want actions to be
-performed.
-
-
 .. toctree::
     :maxdepth: 2
     :hidden:
 
     index
+    producing
+    queues
     drivers
     serializers
     consuming

--- a/doc/producing.rst
+++ b/doc/producing.rst
@@ -1,0 +1,38 @@
+Producing messages
+==================
+
+Any message sent to Bernard must be an instance of ``Bernard\Message``,
+which has a ``getName`` and ``getQueue`` method. ``getName`` is used when working on
+messages and identifies the worker service that should work on it.
+
+A message is given to a producer that sends the message to the right queue.
+It is also possible to get the queue directly from the queue factory and push
+the message there. But remember to wrap the message in an ``Envelope`` object.
+The easiest way is to give it to the producer, as the queue name
+is taken from the message object.
+
+To make it easier to send messages and not require every type to be implemented
+in a separate class, a ``Bernard\Message\DefaultMessage`` is provided. It can hold
+any number of properties and only needs a name for the message. The queue name
+is then generated from that. When generating the queue name it will insert a "_"
+before any uppercase letter and then lowercase the name.
+
+.. code-block:: php
+
+    <?php
+
+    use Bernard\Message\DefaultMessage;
+    use Bernard\Producer;
+    use Bernard\QueueFactory\PersistentFactory;
+    use Bernard\Serializer;
+
+    //.. create $driver
+    $factory = new PersistentFactory($driver, new Serializer());
+    $producer = new Producer($factory);
+
+    $message = new DefaultMessage('SendNewsletter', array(
+        'newsletterId' => 12,
+    ));
+
+    $producer->produce($message);
+

--- a/doc/queues.rst
+++ b/doc/queues.rst
@@ -1,0 +1,22 @@
+Queues
+======
+
+Bernard comes with a few built-in queues
+
+Persistent queue
+----------------
+
+The default queue to use, it produces message to and consumes messages from a driver's queue
+
+Roundrobin queue
+----------------
+
+With the roundrobin queue you can produce messages to multiple queues
+
+In Memory Queue
+---------------
+
+Bernard comes with an implementation for ``SplQueue`` which is completly in memory.
+It is useful for development and/or testing, when you don't necessarily want actions to be
+performed.
+


### PR DESCRIPTION
I've started on the rewrite of the docs to get this library ready for a stable release. All feedback is welcome and I will list the things that are still left to fix/document in the PR

I have also created a temporary readthedocs page to see the changes in the actual template: https://bernard-fork.readthedocs.org/en/docs_rewrite/ (these pages are private so they will not cause confusing the the real docs and will be deleted when this PR is merged)

TODO:

- [x] Move queue docs from producing to separate queue page (inMemory, persistent, roundrobin)
- [ ] Serializers

