### PR TITLE
doctrine driver: Fix unbounded query in popMessage

### DIFF
--- a/src/Driver/DoctrineDriver.php
+++ b/src/Driver/DoctrineDriver.php
@@ -158,7 +158,7 @@ class DoctrineDriver implements \Bernard\Driver
     {
         $query = 'SELECT id, message FROM bernard_messages
                   WHERE queue = :queue AND visible = :visible
-                  ORDER BY sentAt, id ' . $this->connection->getDatabasePlatform()->getForUpdateSql();
+                  ORDER BY sentAt, id LIMIT 1 ' . $this->connection->getDatabasePlatform()->getForUpdateSql();
 
         list($id, $message) = $this->connection->fetchArray($query, [
             'queue' => $queueName,


### PR DESCRIPTION
No need to send all rows over the wire when we only need one.