### PR TITLE
Add support for using v3 of the AWS SDK for PHP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ php:
 
 sudo: false
 
+env:
+  - COMPOSER_OPTS=""
+  - COMPOSER_OPTS="--prefer-lowest"
+
 cache:
   directories:
     - $HOME/.composer/cache/files

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         "symfony/dependency-injection": "~2.3|~3.0",
         "doctrine/dbal": "~2.3",
         "iron-io/iron_mq": "~1.4",
-        "aws/aws-sdk-php": "~2.4",
+        "aws/aws-sdk-php": "~2.4|~3.0",
         "pda/pheanstalk": "~3.0",
         "league/container": "~1.0",
         "php-amqplib/php-amqplib": "~2.5"

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "php": "~5.4|~7.0",
         "bernard/normalt": "~1.0",
         "symfony/event-dispatcher": "~2.3|~3.0",
-        "beberlei/assert": "~2.0"
+        "beberlei/assert": "~2.1"
     },
     "require-dev" : {
         "psr/log": "~1.0",
@@ -23,7 +23,8 @@
         "aws/aws-sdk-php": "~2.4|~3.0",
         "pda/pheanstalk": "~3.0",
         "league/container": "~1.0",
-        "php-amqplib/php-amqplib": "~2.5"
+        "php-amqplib/php-amqplib": "~2.5",
+        "phpspec/phpspec": "~2.0"
     },
     "suggest": {
         "php-amqplib/php-amqplib": "Allow sending messages to an AMQP server using php-amqplib",

--- a/src/Driver/SqsDriver.php
+++ b/src/Driver/SqsDriver.php
@@ -2,11 +2,12 @@
 
 namespace Bernard\Driver;
 
+use Aws\Sqs\Exception\SqsException;
 use Aws\Sqs\SqsClient;
 
 /**
  * Implements a Driver for use with AWS SQS client API:
- * http://docs.aws.amazon.com/aws-sdk-php-2/latest/class-Aws.Sqs.SqsClient.html
+ * @link http://docs.aws.amazon.com/aws-sdk-php/v3/api/api-sqs-2012-11-05.html
  *
  * @package Bernard
  */
@@ -171,19 +172,7 @@ class SqsDriver extends AbstractPrefetchDriver
             return $this->queueUrls[$queueName];
         }
 
-        try {
-            $result = $this->sqs->getQueueUrl(['QueueName' => $queueName]);
-        } catch (SqsException $exception) {
-            if ($exception->getExceptionCode() === 'AWS.SimpleQueueService.NonExistentQueue') {
-                throw new SqsException(
-                    'The queue "' . $queueName . '" is neither aliased locally to an SQS URL nor could it be resolved by SQS.',
-                    $exception->getCode(),
-                    $exception
-                );
-            }
-
-            throw $exception;
-        }
+        $result = $this->sqs->getQueueUrl(['QueueName' => $queueName]);
 
         if ($result && $queueUrl = $result->get('QueueUrl')) {
             return $this->queueUrls[$queueName] = $queueUrl;

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -8,9 +8,10 @@ fi
 
 if [ $TRAVIS_PHP_VERSION = "hhvm" ]; then
 	composer require --dev mongofill/mongofill=dev-master --no-update;
+	composer update --no-progress --no-plugins;
+else
+    composer update --no-progress --no-plugins $COMPOSER_OPTS;
 fi
 
-composer require --dev phpspec/phpspec:~2.0 --no-update
-composer install --no-progress --no-plugins
 mysql -e "CREATE DATABASE bernard_test;"
 psql -c 'CREATE DATABASE bernard_test;' -U postgres


### PR DESCRIPTION
The SQS client didn't change dramatically from v2 to v3, so this PR will support both.