### PR TITLE
Final class with all dispatched events

### DIFF
--- a/src/BernardEvents.php
+++ b/src/BernardEvents.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Bernard;
+
+/**
+ * Contains all events dispatched by bernard
+ */
+final class BernardEvents
+{
+    /**
+     * The PING event occurs each time when bernard starts the consume loop.
+     *
+     * The event listener method receives a Bernard\Event\PingEvent instance.
+     */
+    const PING = 'bernard.ping';
+
+    /**
+     * The INVOKE event occurs each time when the consumption of a message is started.
+     *
+     * The event listener method receives a Bernard\Event\EnvelopeEvent instance.
+     */
+    const INVOKE = 'bernard.invoke';
+
+    /**
+     * The ACKNOWLEDGE event occurs when a message is acknowledged.
+     *
+     * The event listener method receives a Bernard\Event\EnvelopeEvent instance.
+     */
+    const ACKNOWLEDGE = 'bernard.acknowledge';
+
+    /**
+     * The REJECT event occurs when a message is rejected.
+     *
+     * This event allows you to handle the exception occured while consuming a message.
+     * The event listener method receives a Bernard\Event\RejectEnvelopeEvent instance.
+     */
+    const REJECT = 'bernard.reject';
+
+    /**
+     * The PRODUCE event occurs when a message is produced.
+     *
+     * The event listener method receives a Bernard\Event\EnvelopeEvent instance.
+     */
+    const PRODUCE = 'bernard.produce';
+}

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -76,7 +76,7 @@ class Consumer
             return true;
         }
 
-        $this->dispatcher->dispatch('bernard.ping', new PingEvent($queue));
+        $this->dispatcher->dispatch(BernardEvents::PING, new PingEvent($queue));
 
         if (!$envelope = $queue->dequeue()) {
             return !$this->options['stop-when-empty'];
@@ -125,7 +125,7 @@ class Consumer
     public function invoke(Envelope $envelope, Queue $queue)
     {
         try {
-            $this->dispatcher->dispatch('bernard.invoke', new EnvelopeEvent($envelope, $queue));
+            $this->dispatcher->dispatch(BernardEvents::INVOKE, new EnvelopeEvent($envelope, $queue));
 
             // for 5.3 support where a function name is not a callable
             call_user_func($this->router->map($envelope), $envelope->getMessage());
@@ -133,13 +133,13 @@ class Consumer
             // We successfully processed the message.
             $queue->acknowledge($envelope);
 
-            $this->dispatcher->dispatch('bernard.acknowledge', new EnvelopeEvent($envelope, $queue));
+            $this->dispatcher->dispatch(BernardEvents::ACKNOWLEDGE, new EnvelopeEvent($envelope, $queue));
         } catch (\Exception $e) {
             // Make sure the exception is not interfering.
             // Previously failing jobs handling have been moved to a middleware.
             //
             // Emit an event to let others log that exception
-            $this->dispatcher->dispatch('bernard.reject', new RejectEnvelopeEvent($envelope, $queue, $e));
+            $this->dispatcher->dispatch(BernardEvents::REJECT, new RejectEnvelopeEvent($envelope, $queue, $e));
 
             if ($this->options['stop-on-error']) {
                 throw $e;

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -34,6 +34,6 @@ class Producer
         $queue = $this->queues->create($queueName);
         $queue->enqueue($envelope = new Envelope($message));
 
-        $this->dispatcher->dispatch('bernard.produce', new EnvelopeEvent($envelope, $queue));
+        $this->dispatcher->dispatch(BernardEvents::PRODUCE, new EnvelopeEvent($envelope, $queue));
     }
 }


### PR DESCRIPTION
I've added a final class with all dispatched events and some info about each event. This makes a more reliable way of hooking into the event without using a hardcoded string eventname