### PR TITLE
Renamed videlalvaro/php-amqplib to php-amqplib/php-amqplib

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,10 @@
         "aws/aws-sdk-php": "~2.4",
         "pda/pheanstalk": "~3.0",
         "league/container": "~1.0",
-        "videlalvaro/php-amqplib": "~2.5"
+        "php-amqplib/php-amqplib": "~2.5"
     },
     "suggest": {
-        "videlalvaro/php-amqplib": "Allow sending messages to an AMQP server using php-amqplib",
+        "php-amqplib/php-amqplib": "Allow sending messages to an AMQP server using php-amqplib",
         "doctrine/dbal": "Allow sending messages to simulated message queue in a database via doctrine dbal",
         "iron-io/iron_mq": "Allow sending messages to IronMQ",
         "pda/pheanstalk": "Allow sending messages to Beanstalk using pheanstalk",

--- a/doc/drivers.rst
+++ b/doc/drivers.rst
@@ -395,7 +395,7 @@ To support message queries, the following index should also be created:
 PhpAmqp / RabbitMQ
 ------------------
 
-The RabbitMQ driver leans on the php-amqp library by Alvaro Videla.
+The RabbitMQ driver leans on the php-amqp library by php-amqplib.
 
 The driver should be constructed with an ``AMQPStreamConnection`` object, an exchange name and optionally the default message
 parameters.


### PR DESCRIPTION
videlalvaro/php-amqplib is not maintained anymore and is moved to php-amqplib/php-amqplib. See php-amqplib/php-amqplib#356