### PR TITLE
PhpRedisDriver > Support SncRedisBundle BaseClient

### DIFF
--- a/src/Driver/PhpRedisDriver.php
+++ b/src/Driver/PhpRedisDriver.php
@@ -2,6 +2,7 @@
 
 namespace Bernard\Driver;
 
+use Snc\RedisBundle\Client\Phpredis\BaseClient;
 use Redis;
 
 /**
@@ -11,13 +12,24 @@ use Redis;
  */
 class PhpRedisDriver implements \Bernard\Driver
 {
+    /**
+     * @var Redis|BaseClient
+     */
     protected $redis;
 
     /**
-     * @param Redis $redis
+     * @param Redis|BaseClient $redis
      */
-    public function __construct(Redis $redis)
+    public function __construct($redis)
     {
+        if (!$redis instanceof Redis && !$redis instanceof BaseClient) {
+            throw new \InvalidArgumentException(sprintf(
+                'Redis must be an instance of %s or %s.',
+                Redis::class,
+                BaseClient::class
+            ));
+        }
+
         $this->redis = $redis;
     }
 

--- a/src/Driver/PhpRedisDriver.php
+++ b/src/Driver/PhpRedisDriver.php
@@ -25,8 +25,8 @@ class PhpRedisDriver implements \Bernard\Driver
         if (!$redis instanceof Redis && !$redis instanceof BaseClient) {
             throw new \InvalidArgumentException(sprintf(
                 'Redis must be an instance of %s or %s.',
-                Redis::class,
-                BaseClient::class
+                'Redis',
+                'Snc\RedisBundle\Client\Phpredis\BaseClient'
             ));
         }
 

--- a/tests/Driver/PhpRedisDriverTest.php
+++ b/tests/Driver/PhpRedisDriverTest.php
@@ -28,6 +28,15 @@ class PhpRedisDriverTest extends \PHPUnit_Framework_TestCase
         $this->connection = new PhpRedisDriver($this->redis);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Redis must be an instance of Redis or Snc\RedisBundle\Client\Phpredis\BaseClient.
+     */
+    public function testItShouldOnlyAcceptSpecificRedisInstances()
+    {
+        new PhpRedisDriver(new \stdClass);
+    }
+
     public function testItImplementsDriverInterface()
     {
         $this->assertInstanceOf('Bernard\Driver', $this->connection);


### PR DESCRIPTION
Since the BernardBundle defaults to [snc_redis.bernard](https://github.com/bernardphp/BernardBundle/blob/5966d1a1d8fa2d35202ec0ae6ab74adfa438b74e/DependencyInjection/Configuration.php#L35) it would be nice to actually support it ;)

SncRedisBundle creates a BaseClient when in `dev` mode that does not extend from `\Redis`.

This PR allows both `\Redis` and `\Snc\RedisBundle\Client\Phpredis\BaseClient` as constructor argument.
