### PR TITLE
doctrine driver: Fix missing space in select ... for update

### DIFF
--- a/src/Bernard/Driver/DoctrineDriver.php
+++ b/src/Bernard/Driver/DoctrineDriver.php
@@ -103,7 +103,7 @@ class DoctrineDriver implements \Bernard\Driver
     {
         $query = 'SELECT id, message FROM bernard_messages
                   WHERE queue = :queue AND visible = :visible
-                  ORDER BY sentAt, id LIMIT 1' . $this->connection->getDatabasePlatform()->getForUpdateSql();
+                  ORDER BY sentAt, id LIMIT 1 ' . $this->connection->getDatabasePlatform()->getForUpdateSql();
 
         list($id, $message) = $this->connection->fetchArray($query, array(
             'queue' => $queueName,


### PR DESCRIPTION
PR #216 has introduced a bug in the doctrine driver. It does not pop messages from a queue anymore and fails silently due to the try ... catch in `DoctrineDriver::popMessage`. After some debugging I've found the error in the **select ... for update** statement that was modified in the linked PR.
Can you release a 0.12.4 with the fix please?