### PR TITLE
Feature: throwable support

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -121,6 +121,9 @@ class Consumer
      *
      * @param Envelope $envelope
      * @param Queue    $queue
+     *
+     * @throws \Exception
+     * @throws \Throwable
      */
     public function invoke(Envelope $envelope, Queue $queue)
     {
@@ -134,16 +137,10 @@ class Consumer
             $queue->acknowledge($envelope);
 
             $this->dispatcher->dispatch(BernardEvents::ACKNOWLEDGE, new EnvelopeEvent($envelope, $queue));
-        } catch (\Exception $e) {
-            // Make sure the exception is not interfering.
-            // Previously failing jobs handling have been moved to a middleware.
-            //
-            // Emit an event to let others log that exception
-            $this->dispatcher->dispatch(BernardEvents::REJECT, new RejectEnvelopeEvent($envelope, $queue, $e));
-
-            if ($this->options['stop-on-error']) {
-                throw $e;
-            }
+        } catch (\Throwable $error) {
+            $this->rejectDispatch($error, $envelope, $queue);
+        } catch (\Exception $exception) {
+            $this->rejectDispatch($exception, $envelope, $queue);
         }
     }
 
@@ -171,5 +168,27 @@ class Consumer
         pcntl_signal(SIGQUIT, [$this, 'shutdown']);
         pcntl_signal(SIGUSR2, [$this, 'pause']);
         pcntl_signal(SIGCONT, [$this, 'resume']);
+    }
+
+    /**
+     * @param \Throwable|\Exception $exception note that the type-hint is missing due to PHP 5.x compat
+     *
+     * @param Envelope              $envelope
+     * @param Queue                 $queue
+     *
+     * @throws \Exception
+     * @throws \Throwable
+     */
+    private function rejectDispatch($exception, Envelope $envelope, Queue $queue)
+    {
+        // Make sure the exception is not interfering.
+        // Previously failing jobs handling have been moved to a middleware.
+        //
+        // Emit an event to let others log that exception
+        $this->dispatcher->dispatch(BernardEvents::REJECT, new RejectEnvelopeEvent($envelope, $queue, $exception));
+
+        if ($this->options['stop-on-error']) {
+            throw $exception;
+        }
     }
 }

--- a/src/Event/RejectEnvelopeEvent.php
+++ b/src/Event/RejectEnvelopeEvent.php
@@ -13,11 +13,11 @@ class RejectEnvelopeEvent extends EnvelopeEvent
     protected $exception;
 
     /**
-     * @param Envelope   $envelope
-     * @param Queue      $queue
-     * @param \Exception $exception
+     * @param Envelope              $envelope
+     * @param Queue                 $queue
+     * @param \Exception|\Throwable $exception
      */
-    public function __construct(Envelope $envelope, Queue $queue, \Exception $exception)
+    public function __construct(Envelope $envelope, Queue $queue, $exception)
     {
         parent::__construct($envelope, $queue);
 
@@ -25,7 +25,7 @@ class RejectEnvelopeEvent extends EnvelopeEvent
     }
 
     /**
-     * @return \Exception
+     * @return \Exception|\Throwable
      */
     public function getException()
     {

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -222,14 +222,8 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
                 })
             );
 
-            $this->consumer->tick($queue, ['stop-on-error' => true]);
+        self::setExpectedException('TypeError');
 
-        try {
-            self::setExpectedException('TypeError');
-
-            self::fail('A TypeError should have been thrown');
-        } catch (\TypeError $error) {
-            // ignored
-        }
+        $this->consumer->tick($queue, ['stop-on-error' => true]);
     }
 }

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -13,6 +13,21 @@ use Bernard\Event\PingEvent;
 
 class ConsumerTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var SimpleRouter
+     */
+    private $router;
+
+    /**
+     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $dispatcher;
+
+    /**
+     * @var Consumer
+     */
+    private $consumer;
+
     public function setUp()
     {
         $this->router = new SimpleRouter;
@@ -179,5 +194,42 @@ class ConsumerTest extends \PHPUnit_Framework_TestCase
         $this->consumer->tick($queue);
 
         $this->assertTrue($service->importUsers);
+    }
+
+    /**
+     * @requires PHP 7.0
+     */
+    public function testWillRejectDispatchOnThrowableError()
+    {
+        $this->router->add('ImportReport', new Fixtures\Service);
+
+        $queue = new InMemoryQueue('send-newsletter');
+        $queue->enqueue(new Envelope(new DefaultMessage('ImportReport')));
+
+        $this->dispatcher->expects(self::at(0))->method('dispatch')->with('bernard.ping');
+        $this->dispatcher->expects(self::at(1))->method('dispatch')->with('bernard.invoke');
+
+        $this
+            ->dispatcher
+            ->expects(self::at(2))
+            ->method('dispatch')
+            ->with(
+                'bernard.reject',
+                self::callback(function (RejectEnvelopeEvent $rejectEnvelope) {
+                    self::assertInstanceOf('TypeError', $rejectEnvelope->getException());
+
+                    return true;
+                })
+            );
+
+            $this->consumer->tick($queue, ['stop-on-error' => true]);
+
+        try {
+            self::setExpectedException('TypeError');
+
+            self::fail('A TypeError should have been thrown');
+        } catch (\TypeError $error) {
+            // ignored
+        }
     }
 }

--- a/tests/Driver/AbstractDoctrineDriverTest.php
+++ b/tests/Driver/AbstractDoctrineDriverTest.php
@@ -19,7 +19,7 @@ abstract class AbstractDoctrineDriverTest extends \PHPUnit_Framework_TestCase
     /**
      * @var DoctrineDriver
      */
-    private $driver;
+    protected $driver;
 
     public function setUp()
     {

--- a/tests/Driver/AbstractDoctrineDriverTest.php
+++ b/tests/Driver/AbstractDoctrineDriverTest.php
@@ -11,6 +11,16 @@ use Doctrine\DBAL\Platforms\MySqlPlatform;
 
 abstract class AbstractDoctrineDriverTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \Doctrine\DBAL\Connection
+     */
+    private $connection;
+
+    /**
+     * @var DoctrineDriver
+     */
+    private $driver;
+
     public function setUp()
     {
         if (defined('HHVM_VERSION')) {
@@ -149,4 +159,9 @@ abstract class AbstractDoctrineDriverTest extends \PHPUnit_Framework_TestCase
 
         return $connection;
     }
+
+    /**
+     * @return \Doctrine\DBAL\Connection
+     */
+    protected abstract function createConnection();
 }

--- a/tests/Event/RejectEnvelopeEventTest.php
+++ b/tests/Event/RejectEnvelopeEventTest.php
@@ -6,6 +6,16 @@ use Bernard\Event\RejectEnvelopeEvent;
 
 class RejectEnvelopeEventTest extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * @var \Bernard\Envelope|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $envelope;
+
+    /**
+     * @var \Bernard\Queue|\PHPUnit_Framework_MockObject_MockObject
+     */
+    private $queue;
+
     public function setUp()
     {
         $this->envelope = $this->getMockBuilder('Bernard\Envelope')
@@ -26,5 +36,16 @@ class RejectEnvelopeEventTest extends \PHPUnit_Framework_TestCase
         $event = new RejectEnvelopeEvent($this->envelope, $this->queue, $e);
 
         $this->assertSame($e, $event->getException());
+    }
+
+    /**
+     * @requires PHP 7.0
+     */
+    public function testCanContainThrowable()
+    {
+        $error = new \TypeError();
+        $event = new RejectEnvelopeEvent($this->envelope, $this->queue, $error);
+
+        self::assertSame($error, $event->getException());
     }
 }

--- a/tests/Fixtures/Service.php
+++ b/tests/Fixtures/Service.php
@@ -20,4 +20,10 @@ class Service
     {
         touch(__DIR__ . '/create_file.test');
     }
+
+    public function importReport(Report $report)
+    {
+        // note: the class hinted on this method does not exist on purpose, as calling this method should cause a
+        //       Throwable to be thrown
+    }
 }


### PR DESCRIPTION
This PR introduces support for PHP 7 `Throwable` errors. This means that anything that would otherwise crash bernardphp hard causes a `RejectEnvelopeEvent` to be fired.