### PR TITLE
Add container-interop aware router

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
         "aws/aws-sdk-php": "~2.4",
         "pda/pheanstalk": "~3.0",
         "league/container": "~1.0",
-        "php-amqplib/php-amqplib": "~2.5"
+        "php-amqplib/php-amqplib": "~2.5",
+        "container-interop/container-interop": "^1.1"
     },
     "suggest": {
         "php-amqplib/php-amqplib": "Allow sending messages to an AMQP server using php-amqplib",

--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -163,13 +163,19 @@ class Consumer
 
     /**
      * Setup signal handlers for unix signals.
+     *
+     * If the process control extension does not exist (e.g. on Windows), ignore the signal handlers.
+     * The difference is that when terminating the consumer, running processes will not stop gracefully
+     * and will terminate immediately.
      */
     protected function bind()
     {
-        pcntl_signal(SIGTERM, [$this, 'shutdown']);
-        pcntl_signal(SIGINT,  [$this, 'shutdown']);
-        pcntl_signal(SIGQUIT, [$this, 'shutdown']);
-        pcntl_signal(SIGUSR2, [$this, 'pause']);
-        pcntl_signal(SIGCONT, [$this, 'resume']);
+        if (function_exists('pcntl_signal')) {
+            pcntl_signal(SIGTERM, [$this, 'shutdown']);
+            pcntl_signal(SIGINT,  [$this, 'shutdown']);
+            pcntl_signal(SIGQUIT, [$this, 'shutdown']);
+            pcntl_signal(SIGUSR2, [$this, 'pause']);
+            pcntl_signal(SIGCONT, [$this, 'resume']);
+        }
     }
 }

--- a/src/Router/ContainerInteropAwareRouter.php
+++ b/src/Router/ContainerInteropAwareRouter.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Bernard\Router;
+
+use Interop\Container\ContainerInterface;
+
+class ContainerInteropAwareRouter extends SimpleRouter
+{
+    /**
+     * @var ContainerInterface
+     */
+    protected $container;
+
+    /**
+     * @param ContainerInterface $container
+     * @param array              $receivers
+     */
+    public function __construct(ContainerInterface $container, array $receivers = array())
+    {
+        $this->container = $container;
+
+        parent::__construct($receivers);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function get($name)
+    {
+        return $this->container->get(parent::get($name));
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function accepts($receiver)
+    {
+        return $this->container->has($receiver);
+    }
+}

--- a/tests/Router/ContainerInteropAwareRouterTest.php
+++ b/tests/Router/ContainerInteropAwareRouterTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Bernard\Tests\Router;
+
+use Bernard\Envelope;
+use Bernard\Message\DefaultMessage;
+use Bernard\Router\ContainerInteropAwareRouter;
+use Interop\Container\ContainerInterface;
+
+class ContainerInteropAwareRouterTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    public function setUp()
+    {
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->has('my.service')->willReturn(true);
+        $container->get('my.service')->willReturn($this->sendNewsLetterHandler());
+
+        $this->container = $container->reveal();
+    }
+
+    public function testAcceptsContainerServiceAsReceiver()
+    {
+        $envelope = new Envelope(new DefaultMessage('SendNewsletter'));
+        $router = new ContainerInteropAwareRouter($this->container, array(
+            'SendNewsletter' => 'my.service',
+        ));
+
+        $this->assertSame($this->container->get('my.service'), $router->map($envelope));
+    }
+
+    private function sendNewsLetterHandler()
+    {
+        return 'var_dump';
+    }
+}

--- a/tests/Router/ContainerInteropAwareRouterTest.php
+++ b/tests/Router/ContainerInteropAwareRouterTest.php
@@ -16,7 +16,7 @@ class ContainerInteropAwareRouterTest extends \PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $container = $this->prophesize(ContainerInterface::class);
+        $container = $this->prophesize('Interop\Container\ContainerInterface');
         $container->has('my.service')->willReturn(true);
         $container->get('my.service')->willReturn($this->sendNewsLetterHandler());
 


### PR DESCRIPTION
The container-interop interface is used widely these days. This PR adds support for all container-interop [compatible containers](https://github.com/container-interop/container-interop#projects-implementing-containerinterface).

It would make more sense to call it `ContainerAwareRouter`, but that one is already taken by Symfony DI. Maybe `ContainerInterfaceAwareRouter` is better. Let me know if I need to rename it to something else.