### PR TITLE
Feature/receipt

### DIFF
--- a/src/Driver/DoctrineDriver.php
+++ b/src/Driver/DoctrineDriver.php
@@ -72,7 +72,7 @@ class DoctrineDriver implements \Bernard\Driver
 
         $this->createQueue($queueName);
         $this->connection->insert('bernard_messages', $data, $types);
-        return $this->connection->lastInsertId();
+        return $this->connection->lastInsertId('bernard_messages_id_seq');
     }
 
     /**

--- a/src/Driver/DoctrineDriver.php
+++ b/src/Driver/DoctrineDriver.php
@@ -72,6 +72,7 @@ class DoctrineDriver implements \Bernard\Driver
 
         $this->createQueue($queueName);
         $this->connection->insert('bernard_messages', $data, $types);
+        return $this->connection->lastInsertId();
     }
 
     /**

--- a/src/Envelope.php
+++ b/src/Envelope.php
@@ -13,6 +13,7 @@ class Envelope
     protected $message;
     protected $class;
     protected $timestamp;
+    protected $receipt;
 
     /**
      * @param Message $message
@@ -41,6 +42,14 @@ class Envelope
     }
 
     /**
+     * @return mixed
+     */
+    public function getReceipt()
+    {
+        return $this->receipt;
+    }
+
+    /**
      * @return string
      */
     public function getClass()
@@ -54,5 +63,13 @@ class Envelope
     public function getTimestamp()
     {
         return $this->timestamp;
+    }
+
+    /**
+     * @param mixed $receipt
+     */
+    public function setReceipt($receipt)
+    {
+        $this->receipt = $receipt;
     }
 }

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -26,7 +26,7 @@ class Producer
     /**
      * @param Message     $message
      * @param string|null $queueName
-     * @return EnvelopeEvent
+     * @return Envelope
      */
     public function produce(Message $message, $queueName = null)
     {
@@ -38,6 +38,6 @@ class Producer
         $event = new EnvelopeEvent($envelope, $queue);
         $this->dispatcher->dispatch(BernardEvents::PRODUCE, $event);
 
-        return $event;
+        return $envelope;
     }
 }

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -26,6 +26,7 @@ class Producer
     /**
      * @param Message     $message
      * @param string|null $queueName
+     * @return EnvelopeEvent
      */
     public function produce(Message $message, $queueName = null)
     {
@@ -34,6 +35,9 @@ class Producer
         $queue = $this->queues->create($queueName);
         $queue->enqueue($envelope = new Envelope($message));
 
-        $this->dispatcher->dispatch(BernardEvents::PRODUCE, new EnvelopeEvent($envelope, $queue));
+        $event = new EnvelopeEvent($envelope, $queue);
+        $this->dispatcher->dispatch(BernardEvents::PRODUCE, $event);
+
+        return $event;
     }
 }

--- a/src/Queue/PersistentQueue.php
+++ b/src/Queue/PersistentQueue.php
@@ -71,6 +71,7 @@ class PersistentQueue extends AbstractQueue
         $receipt = $this->driver->pushMessage($this->name, $this->serializer->serialize($envelope));
 
         if ($receipt) {
+            $envelope->setReceipt($receipt);
             $this->receipts->attach($envelope, $receipt);
         }
     }
@@ -101,6 +102,7 @@ class PersistentQueue extends AbstractQueue
         if ($serialized) {
             $envelope = $this->serializer->unserialize($serialized);
 
+            $envelope->setReceipt($receipt);
             $this->receipts->attach($envelope, $receipt);
 
             return $envelope;
@@ -123,7 +125,8 @@ class PersistentQueue extends AbstractQueue
      * @param Envelope $envelope The envelope.
      * @return mixed
      */
-    public function getReceipt(Envelope $envelope) {
+    public function getReceipt(Envelope $envelope)
+    {
         if (!$this->receipts->contains($envelope)) {
             return null;
         }

--- a/tests/Driver/AbstractDoctrineDriverTest.php
+++ b/tests/Driver/AbstractDoctrineDriverTest.php
@@ -76,7 +76,7 @@ abstract class AbstractDoctrineDriverTest extends \PHPUnit_Framework_TestCase
 
     public function testPushMessageLazilyCreatesQueue()
     {
-        $this->driver->pushMessage('send-newsletter', 'something');
+        $this->assertNotNull($this->driver->pushMessage('send-newsletter', 'something'));
         $this->assertEquals(array('send-newsletter'), $this->driver->listQueues());
     }
 
@@ -92,8 +92,9 @@ abstract class AbstractDoctrineDriverTest extends \PHPUnit_Framework_TestCase
 
     public function testItIsAQueue()
     {
-        $this->driver->pushMessage('send-newsletter', 'my-message-1');
-        $this->driver->pushMessage('send-newsletter', 'my-message-2');
+        $id = $this->driver->pushMessage('send-newsletter', 'my-message-1');
+        $this->assertGreaterThan(0, $id);
+        $this->assertEquals($id + 1, $this->driver->pushMessage('send-newsletter', 'my-message-2'));
 
         // peeking
         $this->assertEquals(array('my-message-1', 'my-message-2'), $this->driver->peekQueue('send-newsletter'));

--- a/tests/ProducerTest.php
+++ b/tests/ProducerTest.php
@@ -33,9 +33,9 @@ class ProducerTest extends \PHPUnit_Framework_TestCase
         $producer = new Producer($queues, $this->dispatcher);
 
         $message = new DefaultMessage('Message');
-        $event = $producer->produce($message, 'my-queue');
+        $envelope = $producer->produce($message, 'my-queue');
 
-        $this->assertEquals($receipt, $event->getQueue()->getReceipt($event->getEnvelope()));
+        $this->assertEquals($receipt, $envelope->getReceipt());
     }
 
     public function testDispatchesEvent()
@@ -48,7 +48,7 @@ class ProducerTest extends \PHPUnit_Framework_TestCase
 
         $message = new DefaultMessage('Message');
 
-        $this->assertInstanceOf('Bernard\Event\EnvelopeEvent', $this->producer->produce($message, 'my-queue'));
+        $this->assertInstanceOf('Bernard\Envelope', $this->producer->produce($message, 'my-queue'));
 
         $this->assertSame($message, $args['envelope']->getMessage());
         $this->assertSame($this->queues->create('my-queue'), $args['queue']);

--- a/tests/ProducerTest.php
+++ b/tests/ProducerTest.php
@@ -5,6 +5,7 @@ namespace Bernard\Tests;
 use Bernard\Producer;
 use Bernard\Message\DefaultMessage;
 use Bernard\QueueFactory\InMemoryFactory;
+use Bernard\QueueFactory\PersistentFactory;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
 class ProducerTest extends \PHPUnit_Framework_TestCase
@@ -14,6 +15,27 @@ class ProducerTest extends \PHPUnit_Framework_TestCase
         $this->queues = new InMemoryFactory;
         $this->dispatcher = new EventDispatcher;
         $this->producer = new Producer($this->queues, $this->dispatcher);
+    }
+
+    public function testDispatchToPersistent()
+    {
+        $driver = $this->getMock('Bernard\Driver');
+        $serializer = $this->getMock('Bernard\Serializer');
+
+        $receipt = 1337;
+        $serializer->expects($this->once())
+            ->method('serialize');
+        $driver->expects($this->once())
+            ->method('pushMessage')
+            ->will($this->returnValue($receipt));
+
+        $queues = new PersistentFactory($driver, $serializer);
+        $producer = new Producer($queues, $this->dispatcher);
+
+        $message = new DefaultMessage('Message');
+        $event = $producer->produce($message, 'my-queue');
+
+        $this->assertEquals($receipt, $event->getQueue()->getReceipt($event->getEnvelope()));
     }
 
     public function testDispatchesEvent()
@@ -26,7 +48,7 @@ class ProducerTest extends \PHPUnit_Framework_TestCase
 
         $message = new DefaultMessage('Message');
 
-        $this->producer->produce($message, 'my-queue');
+        $this->assertInstanceOf('Bernard\Event\EnvelopeEvent', $this->producer->produce($message, 'my-queue'));
 
         $this->assertSame($message, $args['envelope']->getMessage());
         $this->assertSame($this->queues->create('my-queue'), $args['queue']);

--- a/tests/Queue/PersistentQueueTest.php
+++ b/tests/Queue/PersistentQueueTest.php
@@ -16,14 +16,18 @@ class PersistentQueueTest extends AbstractQueueTest
     public function testEnqueue()
     {
         $envelope = new Envelope($this->getMock('Bernard\Message'));
+        $receipt = 1337;
 
         $this->serializer->expects($this->once())->method('serialize')->with($this->equalTo($envelope))
             ->will($this->returnValue('serialized message'));
         $this->driver->expects($this->once())->method('pushMessage')
-            ->with($this->equalTo('send-newsletter'), $this->equalTo('serialized message'));
+            ->with($this->equalTo('send-newsletter'), $this->equalTo('serialized message'))
+            ->will($this->returnValue($receipt));
 
         $queue = $this->createQueue('send-newsletter');
         $queue->enqueue($envelope);
+
+        $this->assertEquals($receipt, $queue->getReceipt($envelope));
     }
 
     public function testAcknowledge()


### PR DESCRIPTION
Ref issue #233.

We could for example have a listener like so:
```php
	public function onAcknowledge(EnvelopeEvent $event) {
		/* receipts does only make sense with the persistent queue */
		if (!($event->getQueue() instanceof Queue\PersistentQueue)) {
			return;
		}

		$receipt = $event->getEnvelope()->getReceipt();
		$this->alertSomeOneThatTheJob($receipt, $isDone);
	}
```

In other events than `onAcknowledge`, we could also do:

```php
$receipt = $event->getQueue()->getReceipt($event->getEnvelope());
```