### PR TITLE
Fixed listQueues() method in FlatFileDriver.

### DIFF
--- a/src/Driver/FlatFileDriver.php
+++ b/src/Driver/FlatFileDriver.php
@@ -29,7 +29,7 @@ class FlatFileDriver implements \Bernard\Driver
      */
     public function listQueues()
     {
-        $it = new \DirectoryIterator($this->baseDirectory, \FilesystemIterator::SKIP_DOTS);
+        $it = new \FilesystemIterator($this->baseDirectory, \FilesystemIterator::SKIP_DOTS);
 
         $queues = [];
 

--- a/tests/Driver/FlatFileDriverTest.php
+++ b/tests/Driver/FlatFileDriverTest.php
@@ -109,12 +109,15 @@ class FlatFileDriverTest extends \PHPUnit_Framework_TestCase
     
     public function testListQueues()
     {
-        $this->driver->createQueue('send-newsletter');
+        $this->driver->createQueue('send-newsletter-1');
         
-        for ($i = 0; $i < 5; $i++) {
-            $this->driver->pushMessage('send-newsletter', 'Job #'.$i);
-        }
-
-        $this->assertCount(6, $this->driver->listQueues());
+        $this->driver->createQueue('send-newsletter-2');
+        $this->driver->pushMessage('send-newsletter-2', 'job #1');
+        
+        $this->driver->createQueue('send-newsletter-3');
+        $this->driver->pushMessage('send-newsletter-3', 'job #1');
+        $this->driver->pushMessage('send-newsletter-3', 'job #2');
+        
+        $this->assertCount(3, $this->driver->listQueues());
     }
 }

--- a/tests/Driver/FlatFileDriverTest.php
+++ b/tests/Driver/FlatFileDriverTest.php
@@ -106,4 +106,15 @@ class FlatFileDriverTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(10, glob($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter'.\DIRECTORY_SEPARATOR.'*.job'));
     }
+    
+    public function testListQueues()
+    {
+        $this->driver->createQueue('send-newsletter');
+        
+        for ($i = 0; $i < 5; $i++) {
+            $this->driver->pushMessage('send-newsletter', 'Job #'.$i);
+        }
+
+        $this->assertCount(6, $this->driver->listQueues());
+    }
 }

--- a/tests/Driver/FlatFileDriverTest.php
+++ b/tests/Driver/FlatFileDriverTest.php
@@ -16,7 +16,7 @@ class FlatFileDriverTest extends \PHPUnit_Framework_TestCase
 
     protected function setUp()
     {
-        $this->baseDir = sys_get_temp_dir().'/bernard-flat';
+        $this->baseDir = sys_get_temp_dir().\DIRECTORY_SEPARATOR.'bernard-flat';
 
         if (!is_dir($this->baseDir)) {
             mkdir($this->baseDir, 0777, true);
@@ -27,7 +27,11 @@ class FlatFileDriverTest extends \PHPUnit_Framework_TestCase
 
     protected function tearDown()
     {
-        system('rm -R '.$this->baseDir);
+        if ((strtoupper(substr(\PHP_OS, 0, 3)) === 'WIN')) {
+            system('rd /s /q '.$this->baseDir);
+        } else {
+            system('rm -R '.$this->baseDir);
+        }
     }
 
     public function testCreate()
@@ -35,7 +39,7 @@ class FlatFileDriverTest extends \PHPUnit_Framework_TestCase
         $this->driver->createQueue('send-newsletter');
         $this->driver->createQueue('send-newsletter');
 
-        $this->assertTrue(is_dir($this->baseDir.'/send-newsletter'));
+        $this->assertTrue(is_dir($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter'));
     }
 
     public function testRemove()
@@ -45,7 +49,7 @@ class FlatFileDriverTest extends \PHPUnit_Framework_TestCase
 
         $this->driver->removeQueue('send-newsletter');
 
-        $this->assertFalse(is_dir($this->baseDir.'/send-newsletter'));
+        $this->assertFalse(is_dir($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter'));
     }
 
     public function testPushMessage()
@@ -53,14 +57,14 @@ class FlatFileDriverTest extends \PHPUnit_Framework_TestCase
         $this->driver->createQueue('send-newsletter');
         $this->driver->pushMessage('send-newsletter', 'test');
 
-        $this->assertCount(1, glob($this->baseDir.'/send-newsletter/*.job'));
+        $this->assertCount(1, glob($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter'.\DIRECTORY_SEPARATOR.'*.job'));
     }
 
     public function testPushMessagePermissions()
     {
         $this->driver = new FlatFileDriver($this->baseDir, 0770);
         $this->testPushMessage();
-        $this->assertEquals('0770', substr(sprintf('%o', fileperms($this->baseDir . '/send-newsletter/1.job')), -4));
+        $this->assertEquals('0770', substr(sprintf('%o', fileperms($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter'.\DIRECTORY_SEPARATOR.'1.job')), -4));
     }
 
     public function testPopMessage()
@@ -87,7 +91,7 @@ class FlatFileDriverTest extends \PHPUnit_Framework_TestCase
 
         $this->driver->acknowledgeMessage('send-newsletter', $message[1]);
 
-        $this->assertCount(0, glob($this->baseDir.'/send-newsletter/*.job'));
+        $this->assertCount(0, glob($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter'.\DIRECTORY_SEPARATOR.'*.job'));
     }
 
     public function testPeekQueue()
@@ -100,6 +104,6 @@ class FlatFileDriverTest extends \PHPUnit_Framework_TestCase
 
         $this->assertCount(3, $this->driver->peekQueue('send-newsletter', 0, 3));
 
-        $this->assertCount(10, glob($this->baseDir.'/send-newsletter/*.job'));
+        $this->assertCount(10, glob($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter'.\DIRECTORY_SEPARATOR.'*.job'));
     }
 }


### PR DESCRIPTION
1) ListQueues() method in FlatFileDriver uses FilesystemIterator instead of DirectoryIterator ( https://github.com/bernardphp/bernard/issues/235 ).
2) Added tests for listQueues() method in FlatFileDriver.
3) Improved tests for FlatFileDriver to work on Windows(R) to.
4) There is one failed test on Windows(R) :

> _Bernard\Tests\Driver\FlatFileDriverTest::testPushMessagePermissions
> Failed asserting that two strings are equal.
> --- Expected
> +++ Actual
> @@ @@
> -'0770'
> +'0666'_