### PR TITLE
Use self to indicate current page in toctree. 

### DIFF
--- a/doc/index.rst
+++ b/doc/index.rst
@@ -39,7 +39,7 @@ This directory is a good source for setting stuff up and can be used as a go to 
     :maxdepth: 2
     :hidden:
 
-    index
+    self
     producing
     queues
     drivers


### PR DESCRIPTION
Fixes build problem for latest doc build. Index was also referenced in the toctree and created a circular references. This is fixed by using the `self` keyword

This should fix the latest build.