### PR TITLE
Fix #251: dbal driver - safe queue creation

### DIFF
--- a/src/Bernard/Driver/DoctrineDriver.php
+++ b/src/Bernard/Driver/DoctrineDriver.php
@@ -3,6 +3,7 @@
 namespace Bernard\Driver;
 
 use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception\ConstraintViolationException;
 
 /**
  * Driver supporting Doctrine DBAL
@@ -34,12 +35,30 @@ class DoctrineDriver implements \Bernard\Driver
 
     /**
      * {@inheritDoc}
+     *
+     * @throws \Exception
      */
     public function createQueue($queueName)
     {
         try {
-            $this->connection->insert('bernard_queues', array('name' => $queueName));
-        } catch (\Exception $e) {
+            $this->connection->transactional(function () use ($queueName) {
+                $queueExistsQb = $this->connection->createQueryBuilder();
+
+                $queueExists = $queueExistsQb
+                    ->select('name')
+                    ->from('bernard_queues')
+                    ->where($queueExistsQb->expr()->eq('name', ':name'))
+                    ->setParameter('name', $queueName)
+                    ->execute();
+
+                if ($queueExists->fetch()) {
+                    // queue was already created
+                    return;
+                }
+
+                $this->connection->insert('bernard_queues', array('name' => $queueName));
+            });
+        } catch (ConstraintViolationException $ignored) {
             // Because SQL server does not support a portable INSERT ON IGNORE syntax
             // this ignores error based on primary key.
         }

--- a/tests/Bernard/Tests/Driver/DoctrineDriverTest.php
+++ b/tests/Bernard/Tests/Driver/DoctrineDriverTest.php
@@ -91,6 +91,24 @@ class DoctrineDriverTest extends \PHPUnit_Framework_TestCase
         }
     }
 
+    public function testConstraintViolationExceptionsAreIgnored()
+    {
+        $connection   = $this->getMockBuilder('Doctrine\DBAL\Connection')->disableOriginalConstructor()->getMock();
+        $queryBuilder = $this->connection->createQueryBuilder();
+        $exception    = $this
+            ->getMockBuilder('Doctrine\DBAL\Exception\ConstraintViolationException')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $connection->expects(self::once())->method('transactional')->willReturnCallback('call_user_func');
+        $connection->expects(self::once())->method('insert')->willThrowException($exception);
+        $connection->expects(self::any())->method('createQueryBuilder')->willReturn($queryBuilder);
+
+        $driver = new DoctrineDriver($connection);
+
+        $driver->createQueue('foo');
+    }
+
     public function testPushMessageLazilyCreatesQueue()
     {
         $this->driver->pushMessage('send-newsletter', 'something');


### PR DESCRIPTION
Since we don't have `UPSERT` support in DBAL (and sadly will not be in it for a while), this PR fixes #251 by providing graceful handling of queue creation.
1. operations are executed in a transaction
2. only unique constraint exceptions are caught (very important! if the DB dies, that's not something we can ignore)
3. avoid causing duplicate key issues, when possible
