### PR TITLE
Use interval value instead of hard coded values

### DIFF
--- a/src/Driver/PhpAmqpDriver.php
+++ b/src/Driver/PhpAmqpDriver.php
@@ -92,12 +92,12 @@ class PhpAmqpDriver implements Driver
      *
      * @return array An array like array($message, $receipt);
      */
-    public function popMessage($queueName, $interval = 5)
+    public function popMessage($queueName, $interval = 10000)
     {
         $message = $this->getChannel()->basic_get($queueName);
         if (!$message) {
             // sleep for 10 ms to prevent hammering CPU
-            usleep(10000);
+            usleep($interval);
 
             return [null, null];
         }


### PR DESCRIPTION
The interval was hard coded and the $interval variable wasn't in use. I changed that follow the comments on the method.

In order to be fair should be a Constant with a fixed value, you only need to give 1ms to the CPU in order to free the processor. 