### PR TITLE
ensure index is used when querying

### DIFF
--- a/src/Driver/DoctrineDriver.php
+++ b/src/Driver/DoctrineDriver.php
@@ -117,7 +117,7 @@ class DoctrineDriver implements \Bernard\Driver
         $parameters = [$queueName, $limit, $index];
         $types = ['string', 'integer', 'integer'];
 
-        $query = 'SELECT message FROM bernard_messages WHERE queue = ? ORDER BY sentAt, id LIMIT ? OFFSET ?';
+        $query = 'SELECT message FROM bernard_messages WHERE queue = ? ORDER BY sentAt LIMIT ? OFFSET ?';
 
         return $this
             ->connection
@@ -158,7 +158,7 @@ class DoctrineDriver implements \Bernard\Driver
     {
         $query = 'SELECT id, message FROM bernard_messages
                   WHERE queue = :queue AND visible = :visible
-                  ORDER BY sentAt, id LIMIT 1 ' . $this->connection->getDatabasePlatform()->getForUpdateSql();
+                  ORDER BY sentAt LIMIT 1 ' . $this->connection->getDatabasePlatform()->getForUpdateSql();
 
         list($id, $message) = $this->connection->fetchArray($query, [
             'queue' => $queueName,

--- a/tests/Driver/AbstractDoctrineDriverTest.php
+++ b/tests/Driver/AbstractDoctrineDriverTest.php
@@ -4,10 +4,8 @@ namespace Bernard\Tests\Driver;
 
 use Bernard\Doctrine\MessagesSchema;
 use Bernard\Driver\DoctrineDriver;
-
-use Doctrine\DBAL\DriverManager;
-use Doctrine\DBAL\Schema\Schema;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Schema\Schema;
 
 abstract class AbstractDoctrineDriverTest extends \PHPUnit_Framework_TestCase
 {
@@ -92,18 +90,30 @@ abstract class AbstractDoctrineDriverTest extends \PHPUnit_Framework_TestCase
 
     public function testItIsAQueue()
     {
-        $this->driver->pushMessage('send-newsletter', 'my-message-1');
-        $this->driver->pushMessage('send-newsletter', 'my-message-2');
+        $messages = array_map(function ($i) {
+            $this->driver->pushMessage('send-newsletter', $message = 'my-message-'.$i);
+            return $message;
+        }, range(1, 6));
+
+        $assertPeek = function (array $peeked, $expectedCount) use ($messages) {
+            self::assertCount($expectedCount, $peeked);
+            foreach ($peeked as $peek) {
+                self::assertContains($peek, $messages);
+            }
+        };
 
         // peeking
-        $this->assertEquals(array('my-message-1', 'my-message-2'), $this->driver->peekQueue('send-newsletter'));
-        $this->assertEquals(array('my-message-2'), $this->driver->peekQueue('send-newsletter', 1));
-        $this->assertEquals(array('my-message-1'), $this->driver->peekQueue('send-newsletter', 0, 1));
-        $this->assertEquals(array(), $this->driver->peekQueue('import-users'));
+        $assertPeek($this->driver->peekQueue('send-newsletter'), 6);
+        $assertPeek($this->driver->peekQueue('send-newsletter', 0, 3), 3);
+        $assertPeek($this->driver->peekQueue('send-newsletter', 1), 5);
 
-        // popping messages
-        $this->assertEquals(array('my-message-1', 1), $this->driver->popMessage('send-newsletter'));
-        $this->assertEquals(array('my-message-2', 2), $this->driver->popMessage('send-newsletter'));
+        $this->assertEquals([], $this->driver->peekQueue('import-users'));
+
+        // popping
+        list($message, $id) = $this->driver->popMessage('send-newsletter');
+        self::assertContains($message, $messages);
+        list($message, $id) = $this->driver->popMessage('send-newsletter');
+        self::assertContains($message, $messages);
 
         // No messages when all are invisible
         $this->assertInternalType('null', $this->driver->popMessage('import-users', 0.0001));


### PR DESCRIPTION
The doctrine driver isn't using the [index](https://github.com/bernardphp/bernard/blob/master/src/Doctrine/MessagesSchema.php#L54) when querying for messages. (This is noticable when you queue up 200k message)

First i tried modifying the index, but whatever I tried, I couldn't make postgres use an index for the current queries.
So i'm removing the secondary order on id. This library does not guarantee ordered message delivery, so i think this is fine.

Tests don't pass because of this change. how would you like to address that?