### PR TITLE
require abstract connection for amqp

### DIFF
--- a/doc/drivers.rst
+++ b/doc/drivers.rst
@@ -306,8 +306,8 @@ PhpAmqp / RabbitMQ
 
 The RabbitMQ driver uses the `php-amqp library by php-amqplib <https://github.com/php-amqplib/php-amqplib>`_.
 
-The driver should be constructed with an ``AMQPStreamConnection`` object, an exchange name and optionally the default message
-parameters.
+The driver should be constructed with a class that extends `AbstractConnection` (for example `AMQPStreamConnection` or `AMQPSocketConnection`),
+an exchange name and optionally the default message parameters.
 
 .. code-block:: php
 

--- a/src/Driver/PhpAmqpDriver.php
+++ b/src/Driver/PhpAmqpDriver.php
@@ -4,13 +4,13 @@ namespace Bernard\Driver;
 
 use Bernard\Driver;
 use PhpAmqpLib\Channel\AMQPChannel;
-use PhpAmqpLib\Connection\AMQPStreamConnection;
+use PhpAmqpLib\Connection\AbstractConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
 class PhpAmqpDriver implements Driver
 {
     /**
-     * @var AMQPStreamConnection
+     * @var AbstractConnection
      */
     private $connection;
 
@@ -29,11 +29,11 @@ class PhpAmqpDriver implements Driver
     private $defaultMessageParams;
 
     /**
-     * @param AMQPStreamConnection $connection
-     * @param string               $exchange
-     * @param array                $defaultMessageParams
+     * @param AbstractConnection $connection
+     * @param string             $exchange
+     * @param array              $defaultMessageParams
      */
-    public function __construct(AMQPStreamConnection $connection, $exchange, array $defaultMessageParams = null)
+    public function __construct(AbstractConnection $connection, $exchange, array $defaultMessageParams = null)
     {
         $this->connection = $connection;
         $this->exchange = $exchange;


### PR DESCRIPTION
Right now `\PhpAmqpLib\Connection\AMQPStreamConnection` is required to operate with amqp. But rules can be relaxed to required `\PhpAmqpLib\Connection\AbstractConnection`.

E.g. `\PhpAmqpLib\Connection\AMQPSocketConnection` is [much faster](https://github.com/php-amqplib/php-amqplib/issues/449) on first connect than stream implementation