### PR TITLE
Add filter whitelist to phpunit config

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,12 @@
         </testsuite>
     </testsuites>
 
+    <filter>
+        <whitelist addUncoveredFilesFromWhitelist="true" processUncoveredFilesFromWhitelist="false">
+            <directory suffix=".php">./src</directory>
+        </whitelist>
+    </filter>
+
     <groups>
         <exclude>
             <group>functional</group>


### PR DESCRIPTION
This enables PHPUnit `--coverage-text` flag to work without warning  if you run test with it
`vendor/bin/phpunit --coverage-text --configuration phpunit.xml.dist`

Removes warning
`Warning:	No whitelist configured for code coverage`

![screen](https://cloud.githubusercontent.com/assets/1689028/22628079/a9c08154-ebcd-11e6-993c-cd8933731fc1.png)
