### PR TITLE
Added IronMQ v4 support. Updated IronMQ package and namespaces.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,8 @@
         "php": "~5.4|~7.0",
         "bernard/normalt": "~1.0",
         "symfony/event-dispatcher": "~2.3|~3.0",
-        "beberlei/assert": "~2.1"
+        "beberlei/assert": "~2.1",
+        "iron-io/iron_mq": "~4.0"
     },
     "require-dev" : {
         "psr/log": "~1.0",
@@ -19,7 +20,6 @@
         "symfony/console": "~2.3|~3.0",
         "symfony/dependency-injection": "~2.3|~3.0",
         "doctrine/dbal": "~2.3",
-        "iron-io/iron_mq": "~1.4",
         "aws/aws-sdk-php": "~2.4|~3.0",
         "pda/pheanstalk": "~3.0",
         "league/container": "~1.0",

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,7 @@
         "php": "~5.4|~7.0",
         "bernard/normalt": "~1.0",
         "symfony/event-dispatcher": "~2.3|~3.0",
-        "beberlei/assert": "~2.1",
-        "iron-io/iron_mq": "~4.0"
+        "beberlei/assert": "~2.1"
     },
     "require-dev" : {
         "psr/log": "~1.0",
@@ -25,7 +24,8 @@
         "league/container": "~1.0",
         "php-amqplib/php-amqplib": "~2.5",
         "phpspec/phpspec": "^2.4",
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8",
+        "iron-io/iron_mq": "~4.0"
     },
     "suggest": {
         "php-amqplib/php-amqplib": "Allow sending messages to an AMQP server using php-amqplib",

--- a/example/ironmq.php
+++ b/example/ironmq.php
@@ -1,6 +1,6 @@
 <?php
 
-use IronMQ;
+use IronMQ\IronMQ;
 use Bernard\Driver\IronMqDriver;
 
 /**

--- a/src/Driver/IronMqDriver.php
+++ b/src/Driver/IronMqDriver.php
@@ -2,7 +2,7 @@
 
 namespace Bernard\Driver;
 
-use IronMQ;
+use IronMQ\IronMQ;
 
 /**
  * Implements a Driver for use with Iron MQ:

--- a/tests/Driver/IronMqDriverTest.php
+++ b/tests/Driver/IronMqDriverTest.php
@@ -8,7 +8,7 @@ class IronMqDriverTest extends \PHPUnit_Framework_TestCase
 {
     public function setUp()
     {
-        $this->ironmq = $this->getMockBuilder('IronMQ')
+        $this->ironmq = $this->getMockBuilder('\IronMQ\IronMQ')
             ->setMethods(array(
                 'getQueue',
                 'getQueues',


### PR DESCRIPTION
The current stable package of IronMQ is v4.0.1. It's namespace has changed from `IronMQ` to `IronMQ\IronMQ`.

This solves the following issue:

```
A PHP Error was encountered

Severity: 4096

Message: Argument 1 passed to Bernard\Driver\IronMqDriver::__construct() must be an instance of IronMQ, instance of IronMQ\IronMQ given, called in /var/www/localhost/CommandBus/Middlewares/BernardMiddleware.php on line 49 and defined

Filename: Driver/IronMqDriver.php

Line Number: 21
```