### PR TITLE
Don't try to create SQS queue if it already exists

### DIFF
--- a/src/Driver/SqsDriver.php
+++ b/src/Driver/SqsDriver.php
@@ -59,9 +59,13 @@ class SqsDriver extends AbstractPrefetchDriver
      */
     public function createQueue($queueName)
     {
-        $this->sqs->createQueue([
-            'QueueName' => $queueName,
-        ]);
+        if (!isset($this->queueUrls[$queueName])) {
+            $result = $this->sqs->createQueue([
+                'QueueName' => $queueName,
+            ]);
+
+            $this->queueUrls[$queueName] = $result['QueueUrl'];
+        }
     }
 
     /**

--- a/src/Driver/SqsDriver.php
+++ b/src/Driver/SqsDriver.php
@@ -59,7 +59,9 @@ class SqsDriver extends AbstractPrefetchDriver
      */
     public function createQueue($queueName)
     {
-        if (!isset($this->queueUrls[$queueName])) {
+        try {
+            $result = $this->resolveUrl($queueName);
+        } catch (\InvalidArgumentException $e) {
             $result = $this->sqs->createQueue([
                 'QueueName' => $queueName,
             ]);

--- a/tests/Driver/SqsDriverTest.php
+++ b/tests/Driver/SqsDriverTest.php
@@ -49,8 +49,16 @@ class SqsDriverTest extends \PHPUnit_Framework_TestCase
         $this->sqs
             ->expects($this->once())
             ->method('createQueue')
-            ->with($this->equalTo(['QueueName' => self::DUMMY_QUEUE_NAME]));
+            ->with($this->equalTo(['QueueName' => self::DUMMY_QUEUE_NAME]))
+            ->will($this->returnValue(
+                $this->wrapResult([
+                    'QueueUrl' => self::DUMMY_QUEUE_URL_PREFIX,
+                ])
+            ));
 
+        // Calling this twice asserts that if queue exists
+        // there won't be attempt to create it.
+        $this->driver->createQueue(self::DUMMY_QUEUE_NAME);
         $this->driver->createQueue(self::DUMMY_QUEUE_NAME);
     }
 


### PR DESCRIPTION
When using `SqsDriver` with AWS Queue that already exists Bernard attempts to create the Queue, thus leading to AWS Exception being thrown.

This will checks and only make an attempt to create queue if queue URL is not known.
Given that queue URL is already known, I think it's safe to assume that queue exists.