### PR TITLE
Adds the ability to specify options to Drivers, Producers and Queues

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -35,8 +35,9 @@ interface Driver
      *
      * @param string $queueName
      * @param string $message
+     * @param array $options
      */
-    public function pushMessage($queueName, $message);
+    public function pushMessage($queueName, $message, array $options = []);
 
     /**
      * Remove the next message in line. And if no message is available

--- a/src/Driver/AppEngineDriver.php
+++ b/src/Driver/AppEngineDriver.php
@@ -48,7 +48,7 @@ class AppEngineDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
         $task = new PushTask($this->resolveEndpoint($queueName), compact('message'));
         $task->add($queueName);

--- a/src/Driver/DoctrineDriver.php
+++ b/src/Driver/DoctrineDriver.php
@@ -61,7 +61,7 @@ class DoctrineDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
         $types = ['string', 'string', 'datetime'];
         $data = [

--- a/src/Driver/FlatFileDriver.php
+++ b/src/Driver/FlatFileDriver.php
@@ -76,7 +76,7 @@ class FlatFileDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
         $queueDir = $this->getQueueDirectory($queueName);
 

--- a/src/Driver/IronMqDriver.php
+++ b/src/Driver/IronMqDriver.php
@@ -67,9 +67,9 @@ class IronMqDriver extends AbstractPrefetchDriver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
-        $this->ironmq->postMessage($queueName, $message);
+        $this->ironmq->postMessage($queueName, $message, $options);
     }
 
     /**

--- a/src/Driver/MongoDBDriver.php
+++ b/src/Driver/MongoDBDriver.php
@@ -58,7 +58,7 @@ class MongoDBDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
         $data = [
             'queue' => (string) $queueName,
@@ -67,7 +67,7 @@ class MongoDBDriver implements \Bernard\Driver
             'visible' => true,
         ];
 
-        $this->messages->insert($data);
+        $this->messages->insert($data, $options);
     }
 
     /**

--- a/src/Driver/PheanstalkDriver.php
+++ b/src/Driver/PheanstalkDriver.php
@@ -49,9 +49,17 @@ class PheanstalkDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
-        $this->pheanstalk->putInTube($queueName, $message);
+        $defaults = [
+            'priority' => PheanstalkInterface::DEFAULT_PRIORITY,
+            'delay' => PheanstalkInterface::DEFAULT_DELAY,
+            'ttr' => PheanstalkInterface::DEFAULT_TTR,
+        ];
+
+        $options = array_merge($defaults, array_intersect_key($options, $defaults));
+
+        $this->pheanstalk->putInTube($queueName, $message, $options['priority'], $options['delay'], $options['ttr']);
     }
 
     /**

--- a/src/Driver/PhpAmqpDriver.php
+++ b/src/Driver/PhpAmqpDriver.php
@@ -82,10 +82,25 @@ class PhpAmqpDriver implements Driver
      * @param string $queueName
      * @param string $message
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
         $amqpMessage = new AMQPMessage($message, $this->defaultMessageParams);
-        $this->getChannel()->basic_publish($amqpMessage, $this->exchange, $queueName);
+
+        $defaults = [
+            'mandatory' => false,
+            'immediate' => false,
+            'ticket' => null,
+        ];
+
+        $options = array_merge($defaults, array_intersect_key($options, $defaults));
+
+        $this->getChannel()->basic_publish(
+            $amqpMessage,
+            $this->exchange,
+            $queueName,
+            $options['mandatory'],
+            $options['immediate'],
+            $options['ticket']);
     }
 
     /**

--- a/src/Driver/PhpRedisDriver.php
+++ b/src/Driver/PhpRedisDriver.php
@@ -48,7 +48,7 @@ class PhpRedisDriver implements \Bernard\Driver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
         $this->redis->rpush($this->resolveKey($queueName), $message);
     }

--- a/src/Driver/SqsDriver.php
+++ b/src/Driver/SqsDriver.php
@@ -92,14 +92,21 @@ class SqsDriver extends AbstractPrefetchDriver
     /**
      * {@inheritdoc}
      */
-    public function pushMessage($queueName, $message)
+    public function pushMessage($queueName, $message, array $options = [])
     {
         $queueUrl = $this->resolveUrl($queueName);
 
-        $this->sqs->sendMessage([
-            'QueueUrl' => $queueUrl,
-            'MessageBody' => $message,
-        ]);
+        if (isset($options['delay'])) {
+            $options['DelaySeconds'] = $options['delay'];
+            unset($options['delay']);
+        }
+
+        $this->sqs->sendMessage(array_merge(
+            $options,
+            [
+                'QueueUrl' => $queueUrl,
+                'MessageBody' => $message,
+            ]));
     }
 
     /**

--- a/src/Producer.php
+++ b/src/Producer.php
@@ -26,13 +26,14 @@ class Producer
     /**
      * @param Message     $message
      * @param string|null $queueName
+     * @param array       $options
      */
-    public function produce(Message $message, $queueName = null)
+    public function produce(Message $message, $queueName = null, array $options = [])
     {
         $queueName = $queueName ?: Util::guessQueue($message);
 
         $queue = $this->queues->create($queueName);
-        $queue->enqueue($envelope = new Envelope($message));
+        $queue->enqueue($envelope = new Envelope($message), $options);
 
         $this->dispatcher->dispatch(BernardEvents::PRODUCE, new EnvelopeEvent($envelope, $queue));
     }

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -40,6 +40,16 @@ interface Queue extends \Countable
     public function acknowledge(Envelope $envelope);
 
     /**
+     * @return array
+     */
+    public function getOptions();
+
+    /**
+     * @param array $options
+     */
+    public function setOptions(array $options);
+    
+    /**
      * Return the queue textual representation, normally this will be name (not the internal key)
      *
      * @return string

--- a/src/Queue.php
+++ b/src/Queue.php
@@ -8,9 +8,11 @@ namespace Bernard;
 interface Queue extends \Countable
 {
     /**
+     * @param array $options
+     *
      * @param Envelope $envelope
      */
-    public function enqueue(Envelope $envelope);
+    public function enqueue(Envelope $envelope, array $options = []);
 
     /**
      * @return Envelope

--- a/src/Queue/AbstractQueue.php
+++ b/src/Queue/AbstractQueue.php
@@ -12,6 +12,7 @@ abstract class AbstractQueue implements \Bernard\Queue
 {
     protected $closed;
     protected $name;
+    protected $options = [];
 
     /**
      * @param string $name
@@ -47,6 +48,22 @@ abstract class AbstractQueue implements \Bernard\Queue
         if ($this->closed) {
             throw new InvalidOperationException(sprintf('Queue "%s" is closed.', $this->name));
         }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
     }
 
     /**

--- a/src/Queue/InMemoryQueue.php
+++ b/src/Queue/InMemoryQueue.php
@@ -37,7 +37,7 @@ class InMemoryQueue extends AbstractQueue
     /**
      * {@inheritdoc}
      */
-    public function enqueue(Envelope $envelope)
+    public function enqueue(Envelope $envelope, array $options = [])
     {
         $this->errorIfClosed();
 

--- a/src/Queue/PersistentQueue.php
+++ b/src/Queue/PersistentQueue.php
@@ -64,11 +64,11 @@ class PersistentQueue extends AbstractQueue
     /**
      * {@inheritdoc}
      */
-    public function enqueue(Envelope $envelope)
+    public function enqueue(Envelope $envelope, array $options = [])
     {
         $this->errorIfClosed();
 
-        $this->driver->pushMessage($this->name, $this->serializer->serialize($envelope));
+        $this->driver->pushMessage($this->name, $this->serializer->serialize($envelope), $options);
     }
 
     /**

--- a/src/Queue/PersistentQueue.php
+++ b/src/Queue/PersistentQueue.php
@@ -92,7 +92,13 @@ class PersistentQueue extends AbstractQueue
     {
         $this->errorIfClosed();
 
-        list($serialized, $receipt) = $this->driver->popMessage($this->name);
+        $duration = // get the wait seconds from the options array or default to 5 seconds
+            (isset($this->options['duration']) 
+                ? (int)$this->options['duration'] 
+                : 0) 
+            ?: 5;
+        
+        list($serialized, $receipt) = $this->driver->popMessage($this->name, $duration);
 
         if ($serialized) {
             $envelope = $this->serializer->unserialize($serialized);

--- a/src/Queue/RoundRobinQueue.php
+++ b/src/Queue/RoundRobinQueue.php
@@ -26,6 +26,11 @@ class RoundRobinQueue implements Queue
     protected $envelopes;
 
     /**
+     * @var array
+     */
+    protected $options = [];
+
+    /**
      * @param Queue[] $queues
      */
     public function __construct(array $queues)
@@ -138,6 +143,22 @@ class RoundRobinQueue implements Queue
         $queue = $this->envelopes[$envelope];
         $queue->acknowledge($envelope);
         $this->envelopes->detach($envelope);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOptions()
+    {
+        return $this->options;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setOptions(array $options)
+    {
+        $this->options = $options;
     }
 
     /**

--- a/src/Queue/RoundRobinQueue.php
+++ b/src/Queue/RoundRobinQueue.php
@@ -45,11 +45,11 @@ class RoundRobinQueue implements Queue
     /**
      * {@inheritdoc}
      */
-    public function enqueue(Envelope $envelope)
+    public function enqueue(Envelope $envelope, array $options = [])
     {
         $this->verifyEnvelope($envelope);
 
-        $this->queues[$envelope->getName()]->enqueue($envelope);
+        $this->queues[$envelope->getName()]->enqueue($envelope, $options);
     }
 
     /**


### PR DESCRIPTION
I'm using bernard in a project where we're primarily using Amazon SQS and PDO in development but want the flexibility to switch to Iron MQ in the future. In the interim we would like to utilize Amazon SQS more efficiently for our purposes, i.e. increase the timeout while long polling and use a delay when queuing certain types of messages.

I've implemented this by adding an optional options array as the last parameter of the relevant interfaces/abstract classes and added optional driver options where applicable, e.g. pheanstalk and sqs both support a delay.

Note: this could potentially be breaking if users have custom implementations of `Bernard\Driver` or `Bernard\Queue` and have changed the signatures of the `pushMessage` and `enqueue` methods respectively.