### PR TITLE
Ensure an integer is returned

### DIFF
--- a/src/Driver/SqsDriver.php
+++ b/src/Driver/SqsDriver.php
@@ -83,7 +83,7 @@ class SqsDriver extends AbstractPrefetchDriver
         ]);
 
         if (isset($result['Attributes']['ApproximateNumberOfMessages'])) {
-            return $result['Attributes']['ApproximateNumberOfMessages'];
+            return (int)$result['Attributes']['ApproximateNumberOfMessages'];
         }
 
         return 0;


### PR DESCRIPTION
As defined by http://php.net/manual/en/class.countable.php and implemented here https://github.com/bernardphp/bernard/blob/2ccb702f0d2ab9a659cdd52d5767081a8597a36f/src/Queue/PersistentQueue.php#L47-L51