### PR TITLE
Typehint using interface instead of concrete implementation

### DIFF
--- a/src/Driver/DoctrineDriver.php
+++ b/src/Driver/DoctrineDriver.php
@@ -2,7 +2,7 @@
 
 namespace Bernard\Driver;
 
-use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Driver\Connection;
 
 /**
  * Driver supporting Doctrine DBAL


### PR DESCRIPTION
Which is a [best practice when working with dependency injection](http://php-di.org/doc/best-practices.html#rules-for-using-a-container-and-dependency-injection)