### PR TITLE
Stopped popped message causing errors when removing queue

### DIFF
--- a/src/Driver/FlatFileDriver.php
+++ b/src/Driver/FlatFileDriver.php
@@ -163,7 +163,7 @@ class FlatFileDriver implements \Bernard\Driver
             \FilesystemIterator::SKIP_DOTS
         );
         $iterator = new \RecursiveIteratorIterator($iterator);
-        $iterator = new \RegexIterator($iterator, '#\.job$#');
+        $iterator = new \RegexIterator($iterator, '#\.job(.proceed)?$#');
 
         foreach ($iterator as $file) {
             /* @var $file \DirectoryIterator */

--- a/tests/Driver/FlatFileDriverTest.php
+++ b/tests/Driver/FlatFileDriverTest.php
@@ -52,6 +52,17 @@ class FlatFileDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertFalse(is_dir($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter'));
     }
 
+    public function testRemoveQueueWithPoppedMessage()
+    {
+        $this->driver->createQueue('send-newsletter');
+        $this->driver->pushMessage('send-newsletter', 'test');
+        $this->driver->popMessage('send-newsletter');
+
+        $this->driver->removeQueue('send-newsletter');
+
+        $this->assertFalse(is_dir($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter'));
+    }
+
     public function testPushMessage()
     {
         $this->driver->createQueue('send-newsletter');


### PR DESCRIPTION
This PR addresses #303, adding '*.job.proceed' to the regex used to find files to delete.