### PR TITLE
nullable arguments for plain/default messages

### DIFF
--- a/src/Normalizer/PlainMessageNormalizer.php
+++ b/src/Normalizer/PlainMessageNormalizer.php
@@ -28,7 +28,9 @@ class PlainMessageNormalizer implements NormalizerInterface, DenormalizerInterfa
      */
     public function denormalize($data, $class, $format = null, array $context = [])
     {
-        Assertion::choicesNotEmpty($data, ['name', 'arguments']);
+        Assertion::notEmptyKey($data, 'name');
+        Assertion::keyExists($data, 'arguments');
+        Assertion::isArray($data['arguments']);
 
         return new PlainMessage($data['name'], $data['arguments']);
     }

--- a/tests/Normalizer/PlainMessageNormalizerTest.php
+++ b/tests/Normalizer/PlainMessageNormalizerTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Bernard\Tests\Normalizer;
+
+use Bernard\Message\PlainMessage;
+use Bernard\Normalizer\PlainMessageNormalizer;
+use PHPUnit_Framework_TestCase;
+
+class PlainMessageNormalizerTest extends PHPUnit_Framework_TestCase
+{
+    public function testDenormalize()
+    {
+        $sut = new PlainMessageNormalizer();
+        $normalized = $sut->denormalize(['name' => 'foobar', 'arguments' => []], null);
+        $this->assertTrue($normalized instanceof PlainMessage);
+    }
+}


### PR DESCRIPTION
The standard serializer uses `choicesNotEmpty` which expects all keys to be not empty. The interface for a plain message tells me the arguments are optional