### PR TITLE
Bump minimum symfony version to 2.7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,15 +9,15 @@
     "require": {
         "php": "^5.6 || ^7.0",
         "bernard/normalt": "~1.0",
-        "symfony/event-dispatcher": "~2.3|~3.0",
+        "symfony/event-dispatcher": "^2.7|^3.0",
         "beberlei/assert": "~2.1"
     },
     "require-dev" : {
         "psr/log": "~1.0",
         "pimple/pimple": "~1.0",
         "predis/predis": "~0.8",
-        "symfony/console": "~2.3|~3.0",
-        "symfony/dependency-injection": "~2.3|~3.0",
+        "symfony/console": "^2.7|^3.0",
+        "symfony/dependency-injection": "^2.7|^3.0",
         "doctrine/dbal": "~2.3",
         "aws/aws-sdk-php": "~2.4|~3.0",
         "pda/pheanstalk": "~3.0",


### PR DESCRIPTION
Symfony 2.3 support ended in may 2017 (https://symfony.com/roadmap?version=2.3#checker). So bumping the minimum requirement for symfony to the current lts 2.7