### PR TITLE
Upgrade phpunit dependency to supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,15 @@ cache:
   directories:
     - $HOME/.composer/cache/files
 
-services: mongodb
+services:
+  - mongodb
+  - mysql
+  - postgresql
 
 before_script:
   - tests/travis.sh
 
 script:
-  - php vendor/bin/phpunit
-  - php vendor/bin/phpunit --group functional
+  - php vendor/bin/phpunit -v
+  - php vendor/bin/phpunit --group functional -v
   - php vendor/bin/phpspec run

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "pda/pheanstalk": "~3.0",
         "php-amqplib/php-amqplib": "~2.5",
         "phpspec/phpspec": "^2.4",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^5.5|^6.0",
         "iron-io/iron_mq": "~4.0",
         "league/container": "~2.3"
     },

--- a/tests/Command/ConsumeCommandTest.php
+++ b/tests/Command/ConsumeCommandTest.php
@@ -6,7 +6,7 @@ use Bernard\Command\ConsumeCommand;
 use Bernard\QueueFactory\InMemoryFactory;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class ConsumeCommandTest extends \PHPUnit_Framework_TestCase
+class ConsumeCommandTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Command/Doctrine/AbstractCommandTest.php
+++ b/tests/Command/Doctrine/AbstractCommandTest.php
@@ -5,7 +5,7 @@ namespace Bernard\Tests\Command\Doctrine;
 use Bernard\Command\Doctrine\AbstractCommand;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class AbstractCommandTest extends \PHPUnit_Framework_TestCase
+class AbstractCommandTest extends \PHPUnit\Framework\TestCase
 {
     protected $command;
 

--- a/tests/Command/Doctrine/BaseCommandTest.php
+++ b/tests/Command/Doctrine/BaseCommandTest.php
@@ -4,7 +4,7 @@ namespace Bernard\Tests\Command\Doctrine;
 
 use Symfony\Component\Console\Tester\CommandTester;
 
-abstract class BaseCommandTest extends \PHPUnit_Framework_TestCase
+abstract class BaseCommandTest extends \PHPUnit\Framework\TestCase
 {
     protected $command;
 

--- a/tests/Command/ProduceCommandTest.php
+++ b/tests/Command/ProduceCommandTest.php
@@ -29,10 +29,11 @@ class ProduceCommandTest extends \PHPUnit\Framework\TestCase
         ));
     }
 
+    /**
+     * @expectedException \RuntimeException
+     */
     public function testInvalidJsonThrowsException()
     {
-        $this->setExpectedException('RuntimeException');
-
         $command = new ProduceCommand($this->producer);
 
         $tester = new CommandTester($command);

--- a/tests/Command/ProduceCommandTest.php
+++ b/tests/Command/ProduceCommandTest.php
@@ -6,7 +6,7 @@ use Bernard\Message\PlainMessage;
 use Bernard\Command\ProduceCommand;
 use Symfony\Component\Console\Tester\CommandTester;
 
-class ProduceCommandTest extends \PHPUnit_Framework_TestCase
+class ProduceCommandTest extends \PHPUnit\Framework\TestCase
 {
     protected $producer;
 

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -33,16 +33,16 @@ class ConsumerTest extends \PHPUnit\Framework\TestCase
         $this->router = new SimpleRouter;
         $this->router->add('ImportUsers', new Fixtures\Service);
 
-        $this->dispatcher = $this->getMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
+        $this->dispatcher = $this->createMock('Symfony\Component\EventDispatcher\EventDispatcherInterface');
         $this->consumer = new Consumer($this->router, $this->dispatcher);
     }
 
     public function testEmitsConsumeEvent()
     {
         $envelope = new Envelope(new PlainMessage('ImportUsers'));
-        $queue = $this->getMock('Bernard\Queue\InMemoryQueue', [
+        $queue = $this->getMockBuilder('Bernard\Queue\InMemoryQueue')->setMethods([
             'dequeue'
-        ], ['queue']);
+        ])->setConstructorArgs(['queue'])->getMock();
 
         $queue->expects($this->once())
             ->method('dequeue')
@@ -128,7 +128,7 @@ class ConsumerTest extends \PHPUnit\Framework\TestCase
 
         $this->router->add('ImportUsers', $service);
 
-        $queue = $this->getMock('Bernard\Queue');
+        $queue = $this->createMock('Bernard\Queue');
         $queue->expects($this->once())->method('dequeue')->will($this->returnValue($envelope));
         $queue->expects($this->once())->method('acknowledge')->with($this->equalTo($envelope));
 
@@ -198,6 +198,7 @@ class ConsumerTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @requires PHP 7.0
+     * @expectedException \TypeError
      */
     public function testWillRejectDispatchOnThrowableError()
     {
@@ -221,8 +222,6 @@ class ConsumerTest extends \PHPUnit\Framework\TestCase
                     return true;
                 })
             );
-
-        $this->setExpectedException('TypeError');
 
         $this->consumer->tick($queue, ['stop-on-error' => true]);
     }

--- a/tests/ConsumerTest.php
+++ b/tests/ConsumerTest.php
@@ -11,7 +11,7 @@ use Bernard\Event\RejectEnvelopeEvent;
 use Bernard\Event\EnvelopeEvent;
 use Bernard\Event\PingEvent;
 
-class ConsumerTest extends \PHPUnit_Framework_TestCase
+class ConsumerTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var SimpleRouter

--- a/tests/Doctrine/ConnectionListenerTest.php
+++ b/tests/Doctrine/ConnectionListenerTest.php
@@ -7,7 +7,7 @@ use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\DBAL\DBALException;
 
-class ConnectionListenerTest extends \PHPUnit_Framework_TestCase
+class ConnectionListenerTest extends \PHPUnit\Framework\TestCase
 {
     protected function setUp()
     {

--- a/tests/Driver/AbstractDoctrineDriverTest.php
+++ b/tests/Driver/AbstractDoctrineDriverTest.php
@@ -7,7 +7,7 @@ use Bernard\Driver\DoctrineDriver;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Schema\Schema;
 
-abstract class AbstractDoctrineDriverTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractDoctrineDriverTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Doctrine\DBAL\Connection

--- a/tests/Driver/AppEngineDriverTest.php
+++ b/tests/Driver/AppEngineDriverTest.php
@@ -5,7 +5,7 @@ namespace Bernard\Tests\Driver;
 use Bernard\Driver\AppEngineDriver;
 use google\appengine\api\taskqueue\PushTask;
 
-class AppEngineDriverTest extends \PHPUnit_Framework_TestCase
+class AppEngineDriverTest extends \PHPUnit\Framework\TestCase
 {
     public static function setUpBeforeClass()
     {

--- a/tests/Driver/FlatFileDriverTest.php
+++ b/tests/Driver/FlatFileDriverTest.php
@@ -7,7 +7,7 @@ use Bernard\Driver\FlatFileDriver;
 /**
  * @author Markus Bachmann <markus.bachmann@bachi.biz>
  */
-class FlatFileDriverTest extends \PHPUnit_Framework_TestCase
+class FlatFileDriverTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var FlatFileDriver

--- a/tests/Driver/IronMqDriverTest.php
+++ b/tests/Driver/IronMqDriverTest.php
@@ -4,7 +4,7 @@ namespace Bernard\Tests\Driver;
 
 use Bernard\Driver\IronMqDriver;
 
-class IronMqDriverTest extends \PHPUnit_Framework_TestCase
+class IronMqDriverTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Driver/MongoDBDriverFunctionalTest.php
+++ b/tests/Driver/MongoDBDriverFunctionalTest.php
@@ -11,7 +11,7 @@ use MongoConnectionException;
  * @coversDefaultClass Bernard\Driver\MongoDBDriver
  * @group functional
  */
-class MongoDBDriverFunctionalTest extends \PHPUnit_Framework_TestCase
+class MongoDBDriverFunctionalTest extends \PHPUnit\Framework\TestCase
 {
     const DATABASE = 'bernardQueueTest';
     const MESSAGES = 'bernardMessages';

--- a/tests/Driver/MongoDBDriverTest.php
+++ b/tests/Driver/MongoDBDriverTest.php
@@ -7,7 +7,7 @@ use ArrayIterator;
 use MongoDate;
 use MongoId;
 
-class MongoDBDriverTest extends \PHPUnit_Framework_TestCase
+class MongoDBDriverTest extends \PHPUnit\Framework\TestCase
 {
     private $messages;
     private $queues;

--- a/tests/Driver/PheanstalkDriverTest.php
+++ b/tests/Driver/PheanstalkDriverTest.php
@@ -5,7 +5,7 @@ namespace Bernard\Tests\Driver;
 use Bernard\Driver\PheanstalkDriver;
 use Pheanstalk\Job;
 
-class PheanstalkDriverTest extends \PHPUnit_Framework_TestCase
+class PheanstalkDriverTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Driver/PhpAmqpDriverTest.php
+++ b/tests/Driver/PhpAmqpDriverTest.php
@@ -28,28 +28,24 @@ class PhpAmqpDriverTest extends \PHPUnit\Framework\TestCase
 
     protected function setUp()
     {
-        $this->phpAmqpChannel = $this->getMock(
-            '\PhpAmqpLib\Channel\AMQPChannel',
-            array(
+        $this->phpAmqpChannel = $this->getMockBuilder('\PhpAmqpLib\Channel\AMQPChannel')
+            ->setMethods(array(
                 'basic_publish',
                 'basic_get',
                 'basic_ack',
                 'exchange_declare',
                 'queue_declare',
                 'queue_bind'
-            ),
-            array(),
-            '',
-            false
-        );
+            ))
+            ->disableOriginalConstructor()
+            ->getMock();
 
-        $this->phpAmqpConnection = $this->getMock(
-            '\PhpAmqpLib\Connection\AMQPStreamConnection',
-            array('channel'),
-            array(),
-            '',
-            false
-        );
+        $this->phpAmqpConnection = $this->getMockBuilder('\PhpAmqpLib\Connection\AMQPStreamConnection')
+            ->setMethods(array(
+                'channel',
+            ))
+            ->disableOriginalConstructor()
+            ->getMock();
 
         $this->phpAmqpConnection
             ->expects($this->any())

--- a/tests/Driver/PhpAmqpDriverTest.php
+++ b/tests/Driver/PhpAmqpDriverTest.php
@@ -7,7 +7,7 @@ use PhpAmqpLib\Channel\AMQPChannel;
 use PhpAmqpLib\Connection\AMQPStreamConnection;
 use PhpAmqpLib\Message\AMQPMessage;
 
-class PhpAmqpDriverTest extends \PHPUnit_Framework_TestCase
+class PhpAmqpDriverTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var AMQPStreamConnection

--- a/tests/Driver/PhpRedisDriverTest.php
+++ b/tests/Driver/PhpRedisDriverTest.php
@@ -12,7 +12,7 @@ class PhpRedisDriverTest extends \PHPUnit\Framework\TestCase
             $this->markTestSkipped('"redis" extension is not loaded.');
         }
 
-        $this->redis = $this->getMock('Redis', array(
+        $this->redis = $this->getMockBuilder('Redis')->setMethods(array(
             'lLen',
             'sMembers',
             'lRange',
@@ -23,7 +23,7 @@ class PhpRedisDriverTest extends \PHPUnit\Framework\TestCase
             'sContains',
             'rPush',
             'sRem',
-        ));
+        ))->getMock();
 
         $this->connection = new PhpRedisDriver($this->redis);
     }

--- a/tests/Driver/PhpRedisDriverTest.php
+++ b/tests/Driver/PhpRedisDriverTest.php
@@ -4,7 +4,7 @@ namespace Bernard\Tests\Driver;
 
 use Bernard\Driver\PhpRedisDriver;
 
-class PhpRedisDriverTest extends \PHPUnit_Framework_TestCase
+class PhpRedisDriverTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Driver/PredisDriverTest.php
+++ b/tests/Driver/PredisDriverTest.php
@@ -10,7 +10,7 @@ class PredisDriverTest extends PhpRedisDriverTest
     {
         // Because predis uses __call all methods that needs mocking must be
         // explicitly defined.
-        $this->redis = $this->getMock('Predis\Client', array(
+        $this->redis = $this->getMockBuilder('Predis\Client')->setMethods(array(
             'lLen',
             'sMembers',
             'lRange',
@@ -21,7 +21,7 @@ class PredisDriverTest extends PhpRedisDriverTest
             'sContains',
             'rPush',
             'sRem',
-        ));
+        ))->getMock();
 
         $this->connection = new PredisDriver($this->redis);
     }

--- a/tests/Driver/PrefetchMessageCacheTest.php
+++ b/tests/Driver/PrefetchMessageCacheTest.php
@@ -4,7 +4,7 @@ namespace Bernard\Tests\Driver;
 
 use Bernard\Driver\PrefetchMessageCache;
 
-class PrefetchMessageCacheTest extends \PHPUnit_Framework_TestCase
+class PrefetchMessageCacheTest extends \PHPUnit\Framework\TestCase
 {
     public function testPushesAndPop()
     {

--- a/tests/Driver/SqsDriverTest.php
+++ b/tests/Driver/SqsDriverTest.php
@@ -92,10 +92,12 @@ class SqsDriverTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals(4, $this->driver->countMessages(self::DUMMY_QUEUE_NAME));
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Queue "unknown" cannot be resolved to an url.
+     */
     public function testUnresolveableQueueNameThrowsException()
     {
-        $this->setExpectedException('InvalidArgumentException', 'Queue "unknown" cannot be resolved to an url.');
-
         $this->driver->popMessage('unknown');
     }
 

--- a/tests/Driver/SqsDriverTest.php
+++ b/tests/Driver/SqsDriverTest.php
@@ -7,7 +7,7 @@ use Aws\Sqs\SqsClient;
 use Bernard\Driver\SqsDriver;
 use Guzzle\Service\Resource\Model;
 
-class SqsDriverTest extends \PHPUnit_Framework_TestCase
+class SqsDriverTest extends \PHPUnit\Framework\TestCase
 {
     const DUMMY_QUEUE_NAME       = 'my-queue';
     const DUMMY_QUEUE_URL_PREFIX = 'https://sqs.eu-west-1.amazonaws.com/123123';

--- a/tests/EnvelopeTest.php
+++ b/tests/EnvelopeTest.php
@@ -5,7 +5,7 @@ namespace Bernard\Tests;
 use Bernard\Message\PlainMessage;
 use Bernard\Envelope;
 
-class EnvelopeTest extends \PHPUnit_Framework_TestCase
+class EnvelopeTest extends \PHPUnit\Framework\TestCase
 {
     public function testItWrapsAMessageWithMetadata()
     {

--- a/tests/Event/EnvelopeEventTest.php
+++ b/tests/Event/EnvelopeEventTest.php
@@ -4,7 +4,7 @@ namespace Bernard\Tests\Event;
 
 use Bernard\Event\EnvelopeEvent;
 
-class EnvelopeEventTest extends \PHPUnit_Framework_TestCase
+class EnvelopeEventTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Event/EnvelopeEventTest.php
+++ b/tests/Event/EnvelopeEventTest.php
@@ -10,7 +10,7 @@ class EnvelopeEventTest extends \PHPUnit\Framework\TestCase
     {
         $this->envelope = $this->getMockBuilder('Bernard\Envelope')->disableOriginalConstructor()
             ->getMock();
-        $this->queue = $this->getMock('Bernard\Queue');
+        $this->queue = $this->createMock('Bernard\Queue');
     }
 
     public function testIsEvent()

--- a/tests/Event/RejectEnvelopeEventTest.php
+++ b/tests/Event/RejectEnvelopeEventTest.php
@@ -4,7 +4,7 @@ namespace Bernard\Tests\Event;
 
 use Bernard\Event\RejectEnvelopeEvent;
 
-class RejectEnvelopeEventTest extends \PHPUnit_Framework_TestCase
+class RejectEnvelopeEventTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var \Bernard\Envelope|\PHPUnit_Framework_MockObject_MockObject

--- a/tests/Event/RejectEnvelopeEventTest.php
+++ b/tests/Event/RejectEnvelopeEventTest.php
@@ -20,7 +20,7 @@ class RejectEnvelopeEventTest extends \PHPUnit\Framework\TestCase
     {
         $this->envelope = $this->getMockBuilder('Bernard\Envelope')
             ->disableOriginalConstructor()->getMock();
-        $this->queue = $this->getMock('Bernard\Queue');
+        $this->queue = $this->createMock('Bernard\Queue');
     }
 
     public function testExtendsEnvelopeEvent()

--- a/tests/EventListener/ErrorLogSubscriberTest.php
+++ b/tests/EventListener/ErrorLogSubscriberTest.php
@@ -4,9 +4,8 @@ namespace Bernard\Tests\EventListener;
 
 use Bernard\Event\RejectEnvelopeEvent;
 use Bernard\EventListener\ErrorLogSubscriber;
-use PHPUnit_Framework_TestCase as TestCase;
 
-class ErrorLogSubscriberTest extends TestCase
+class ErrorLogSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     private $envelope;
     private $queue;

--- a/tests/EventListener/ErrorLogSubscriberTest.php
+++ b/tests/EventListener/ErrorLogSubscriberTest.php
@@ -22,7 +22,7 @@ class ErrorLogSubscriberTest extends \PHPUnit\Framework\TestCase
 
         $this->envelope = $this->getMockBuilder('Bernard\Envelope')
             ->disableOriginalConstructor()->getMock();
-        $this->queue = $this->getMock('Bernard\Queue');
+        $this->queue = $this->createMock('Bernard\Queue');
         $this->producer = $this->getMockBuilder('Bernard\Producer')->disableOriginalConstructor()->getMock();
         $this->subscriber = new ErrorLogSubscriber($this->producer, 'failures');
         $this->iniErrorLog = ini_get('error_log');

--- a/tests/EventListener/FailureSubscriberTest.php
+++ b/tests/EventListener/FailureSubscriberTest.php
@@ -8,7 +8,7 @@ use Bernard\EventListener\FailureSubscriber;
 use Bernard\Message\DefaultMessage;
 use Bernard\Queue\InMemoryQueue;
 
-class FailureSubscriberTest extends \PHPUnit_Framework_TestCase
+class FailureSubscriberTest extends \PHPUnit\Framework\TestCase
 {
     private $producer;
     private $subscriber;

--- a/tests/Exception/ExceptionTest.php
+++ b/tests/Exception/ExceptionTest.php
@@ -2,9 +2,7 @@
 
 namespace Bernard\Tests\Exception;
 
-use PHPUnit_Framework_TestCase as TestCase;
-
-class ExceptionTest extends TestCase
+class ExceptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider exceptionProvider

--- a/tests/Message/AbstractMessageTest.php
+++ b/tests/Message/AbstractMessageTest.php
@@ -4,7 +4,7 @@ namespace Bernard\Tests\Message;
 
 use Bernard\Tests\Fixtures;
 
-class AbstractMessageTest extends \PHPUnit_Framework_TestCase
+class AbstractMessageTest extends \PHPUnit\Framework\TestCase
 {
     public function testImplementsMessage()
     {

--- a/tests/Message/PlainMessageTest.php
+++ b/tests/Message/PlainMessageTest.php
@@ -4,7 +4,7 @@ namespace Bernard\Tests\Message;
 
 use Bernard\Message\PlainMessage;
 
-class PlainMessageTest extends \PHPUnit_Framework_TestCase
+class PlainMessageTest extends \PHPUnit\Framework\TestCase
 {
     public function testItHaveAName()
     {

--- a/tests/Normalizer/PlainMessageNormalizerTest.php
+++ b/tests/Normalizer/PlainMessageNormalizerTest.php
@@ -4,9 +4,8 @@ namespace Bernard\Tests\Normalizer;
 
 use Bernard\Message\PlainMessage;
 use Bernard\Normalizer\PlainMessageNormalizer;
-use PHPUnit_Framework_TestCase;
 
-class PlainMessageNormalizerTest extends PHPUnit_Framework_TestCase
+class PlainMessageNormalizerTest extends \PHPUnit\Framework\TestCase
 {
     public function testDenormalize()
     {

--- a/tests/ProducerTest.php
+++ b/tests/ProducerTest.php
@@ -7,7 +7,7 @@ use Bernard\Message\PlainMessage;
 use Bernard\QueueFactory\InMemoryFactory;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
-class ProducerTest extends \PHPUnit_Framework_TestCase
+class ProducerTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Queue/AbstractQueueTest.php
+++ b/tests/Queue/AbstractQueueTest.php
@@ -8,11 +8,11 @@ abstract class AbstractQueueTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider dataClosedMethods
+     * @expectedException \Bernard\Exception\InvalidOperationexception
+     * @expectedExceptionMessage Queue "send-newsletter" is closed.
      */
     public function testNotAllowedWhenClosed($method, array $arguments = array())
     {
-        $this->setExpectedException('Bernard\Exception\InvalidOperationexception', 'Queue "send-newsletter" is closed.');
-
         $queue = $this->createQueue('send-newsletter');
         $queue->close();
 
@@ -34,10 +34,10 @@ abstract class AbstractQueueTest extends \PHPUnit\Framework\TestCase
             array('count'),
             array('dequeue'),
             array('enqueue', array(
-                new Envelope($this->getMock('Bernard\Message'))
+                new Envelope($this->createMock('Bernard\Message'))
             )),
             array('acknowledge', array(
-                new Envelope($this->getMock('Bernard\Message'))
+                new Envelope($this->createMock('Bernard\Message'))
             )),
         );
     }

--- a/tests/Queue/AbstractQueueTest.php
+++ b/tests/Queue/AbstractQueueTest.php
@@ -4,7 +4,7 @@ namespace Bernard\Tests\Queue;
 
 use Bernard\Envelope;
 
-abstract class AbstractQueueTest extends \PHPUnit_Framework_TestCase
+abstract class AbstractQueueTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @dataProvider dataClosedMethods

--- a/tests/Queue/InMemoryQueueTest.php
+++ b/tests/Queue/InMemoryQueueTest.php
@@ -9,7 +9,7 @@ class InMemoryQueueTest extends AbstractQueueTest
 {
     public function testDequeue()
     {
-        $envelope = new Envelope($this->getMock('Bernard\Message'));
+        $envelope = new Envelope($this->createMock('Bernard\Message'));
 
         $queue = $this->createQueue('send-newsletter');
         $queue->enqueue($envelope);
@@ -41,7 +41,7 @@ class InMemoryQueueTest extends AbstractQueueTest
 
     protected function getEnvelope()
     {
-        return new Envelope($this->getMock('Bernard\Message'));
+        return new Envelope($this->createMock('Bernard\Message'));
     }
 
     protected function createQueue($name)

--- a/tests/Queue/PersistentQueueTest.php
+++ b/tests/Queue/PersistentQueueTest.php
@@ -9,13 +9,13 @@ class PersistentQueueTest extends AbstractQueueTest
 {
     public function setUp()
     {
-        $this->driver = $this->getMock('Bernard\Driver');
-        $this->serializer = $this->getMock('Bernard\Serializer');
+        $this->driver = $this->createMock('Bernard\Driver');
+        $this->serializer = $this->createMock('Bernard\Serializer');
     }
 
     public function testEnqueue()
     {
-        $envelope = new Envelope($this->getMock('Bernard\Message'));
+        $envelope = new Envelope($this->createMock('Bernard\Message'));
 
         $this->serializer->expects($this->once())->method('serialize')->with($this->equalTo($envelope))
             ->will($this->returnValue('serialized message'));
@@ -28,7 +28,7 @@ class PersistentQueueTest extends AbstractQueueTest
 
     public function testAcknowledge()
     {
-        $envelope = new Envelope($this->getMock('Bernard\Message'));
+        $envelope = new Envelope($this->createMock('Bernard\Message'));
 
         $this->driver->expects($this->once())->method('acknowledgeMessage')
             ->with($this->equalTo('send-newsletter'), $this->equalTo('receipt'));
@@ -46,7 +46,7 @@ class PersistentQueueTest extends AbstractQueueTest
 
     public function testAcknowledgeOnlyIfReceipt()
     {
-        $envelope = new Envelope($this->getMock('Bernard\Message'));
+        $envelope = new Envelope($this->createMock('Bernard\Message'));
 
         $this->driver->expects($this->never())->method('acknowledgeMessage');
 
@@ -66,7 +66,7 @@ class PersistentQueueTest extends AbstractQueueTest
 
     public function testDequeue()
     {
-        $messageWrapper = new Envelope($this->getMock('Bernard\Message'));
+        $messageWrapper = new Envelope($this->createMock('Bernard\Message'));
 
         $this->driver->expects($this->at(1))->method('popMessage')->with($this->equalTo('send-newsletter'))
             ->will($this->returnValue(array('serialized', null)));

--- a/tests/Queue/RoundRobinQueueTest.php
+++ b/tests/Queue/RoundRobinQueueTest.php
@@ -30,13 +30,12 @@ class RoundRobinQueueTest extends \PHPUnit\Framework\TestCase
         $this->round = new RoundRobinQueue($this->queues);
     }
 
+    /**
+     * @expectedException \DomainException
+     * @expectedExceptionMessage Unrecognized queue specified: foo
+     */
     public function testEnqueueWithUnrecognizedQueue()
     {
-        $this->setExpectedException(
-            'DomainException',
-            'Unrecognized queue specified: foo'
-        );
-
         $this->round->enqueue($this->getEnvelope('foo'));
     }
 
@@ -94,13 +93,12 @@ class RoundRobinQueueTest extends \PHPUnit\Framework\TestCase
         $this->assertSame([$envelope_3_1], $this->round->peek(1, 1));
     }
 
+    /**
+     * @expectedException \DomainException
+     * @expectedExceptionMessage Unrecognized queue specified: foo
+     */
     public function testAcknowledgeWithUnrecognizedQueue()
     {
-        $this->setExpectedException(
-            'DomainException',
-            'Unrecognized queue specified: foo'
-        );
-
         $envelope = $this->getEnvelope('foo');
         $this->round->enqueue($envelope);
         $dequeued = $this->round->dequeue($envelope);

--- a/tests/Queue/RoundRobinQueueTest.php
+++ b/tests/Queue/RoundRobinQueueTest.php
@@ -7,7 +7,7 @@ use Bernard\Message\PlainMessage;
 use Bernard\Queue\InMemoryQueue;
 use Bernard\Queue\RoundRobinQueue;
 
-class RoundRobinQueueTest extends \PHPUnit_Framework_TestCase
+class RoundRobinQueueTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * @var InMemoryQueue[]

--- a/tests/QueueFactory/InMemoryFactoryTest.php
+++ b/tests/QueueFactory/InMemoryFactoryTest.php
@@ -4,7 +4,7 @@ namespace Bernard\Tests;
 
 use Bernard\QueueFactory\InMemoryFactory;
 
-class InMemoryFactoryTest extends \PHPUnit_Framework_TestCase
+class InMemoryFactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/QueueFactory/InMemoryFactoryTest.php
+++ b/tests/QueueFactory/InMemoryFactoryTest.php
@@ -16,10 +16,11 @@ class InMemoryFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('Bernard\QueueFactory', $this->factory);
     }
 
+    /**
+     * @expectedException \Bernard\Exception\InvalidOperationException
+     */
     public function testRemoveClosesQueue()
     {
-        $this->setExpectedException('Bernard\Exception\InvalidOperationException');
-
         $queue = $this->factory->create('queue');
 
         $this->assertTrue($this->factory->exists('queue'));

--- a/tests/QueueFactory/PersistentFactoryTest.php
+++ b/tests/QueueFactory/PersistentFactoryTest.php
@@ -4,7 +4,7 @@ namespace Bernard\Tests\QueueFactory;
 
 use Bernard\QueueFactory\PersistentFactory;
 
-class PersistentFactoryTest extends \PHPUnit_Framework_TestCase
+class PersistentFactoryTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/QueueFactory/PersistentFactoryTest.php
+++ b/tests/QueueFactory/PersistentFactoryTest.php
@@ -11,7 +11,7 @@ class PersistentFactoryTest extends \PHPUnit\Framework\TestCase
         $this->connection = $this->getMockBuilder('Bernard\Driver')
             ->disableOriginalConstructor()->getMock();
 
-        $this->factory = new PersistentFactory($this->connection, $this->getMock('Bernard\Serializer'));
+        $this->factory = new PersistentFactory($this->connection, $this->createMock('Bernard\Serializer'));
     }
 
     public function testImplementsQueueFactory()
@@ -29,10 +29,11 @@ class PersistentFactoryTest extends \PHPUnit\Framework\TestCase
         $this->assertSame($queue, $this->factory->create('send-newsletter'));
     }
 
+    /**
+     * @expectedException \Bernard\Exception\InvalidOperationException
+     */
     public function testRemoveClosesQueue()
     {
-        $this->setExpectedException('Bernard\Exception\InvalidOperationException');
-
         $queue = $this->factory->create('send-newsletter');
 
         $this->assertTrue($this->factory->exists('send-newsletter'));

--- a/tests/Router/ContainerAwareRouterTest.php
+++ b/tests/Router/ContainerAwareRouterTest.php
@@ -17,10 +17,11 @@ class ContainerAwareRouterTest extends \PHPUnit\Framework\TestCase
         });
     }
 
+    /**
+     * @expectedException \Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException
+     */
     public function testUndefinedServicesAreNotAccepted()
     {
-        $this->setExpectedException('Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException');
-
         $envelope = new Envelope(new PlainMessage('SendNewsletter'));
 
         $router = new ContainerAwareRouter($this->container);

--- a/tests/Router/ContainerAwareRouterTest.php
+++ b/tests/Router/ContainerAwareRouterTest.php
@@ -7,7 +7,7 @@ use Bernard\Message\PlainMessage;
 use Bernard\Router\ContainerAwareRouter;
 use Symfony\Component\DependencyInjection\Container;
 
-class ContainerAwareRouterTest extends \PHPUnit_Framework_TestCase
+class ContainerAwareRouterTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Router/LeagueContainerAwareRouterTest.php
+++ b/tests/Router/LeagueContainerAwareRouterTest.php
@@ -7,7 +7,7 @@ use Bernard\Message\PlainMessage;
 use Bernard\Router\LeagueContainerAwareRouter;
 use League\Container\Container;
 
-class LeagueContainerAwareRouterTest extends \PHPUnit_Framework_TestCase
+class LeagueContainerAwareRouterTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Router/LeagueContainerAwareRouterTest.php
+++ b/tests/Router/LeagueContainerAwareRouterTest.php
@@ -17,10 +17,11 @@ class LeagueContainerAwareRouterTest extends \PHPUnit\Framework\TestCase
         });
     }
 
+    /**
+     * @expectedException \League\Container\Exception\NotFoundException
+     */
     public function testUndefinedServicesAreNotAccepted()
     {
-        $this->setExpectedException('League\Container\Exception\NotFoundException');
-
         $envelope = new Envelope(new PlainMessage('SendNewsletter'));
 
         $router = new LeagueContainerAwareRouter($this->container);

--- a/tests/Router/PimpleAwareRouterTest.php
+++ b/tests/Router/PimpleAwareRouterTest.php
@@ -19,10 +19,11 @@ class PimpleAwareRouterTest extends \PHPUnit\Framework\TestCase
         $this->router = new PimpleAwareRouter($this->pimple);
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testUndefinedServicesAreNotAccepted()
     {
-        $this->setExpectedException('InvalidArgumentException');
-
         $envelope = new Envelope(new PlainMessage('SendNewsletter'));
 
         $this->router->map($envelope);

--- a/tests/Router/PimpleAwareRouterTest.php
+++ b/tests/Router/PimpleAwareRouterTest.php
@@ -7,7 +7,7 @@ use Bernard\Message\PlainMessage;
 use Bernard\Router\PimpleAwareRouter;
 use Pimple;
 
-class PimpleAwareRouterTest extends \PHPUnit_Framework_TestCase
+class PimpleAwareRouterTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/Router/SimpleRouterTest.php
+++ b/tests/Router/SimpleRouterTest.php
@@ -13,17 +13,19 @@ class SimpleRouterTest extends \PHPUnit\Framework\TestCase
         $this->router = new SimpleRouter();
     }
 
+    /**
+     * @expectedException \InvalidArgumentException
+     */
     public function testThrowsExceptionWhenReceiverIsNotSupported()
     {
-        $this->setExpectedException('InvalidArgumentException');
-
         $this->router->add('SendNewsletter', 1);
     }
 
+    /**
+     * @expectedException \Bernard\Exception\ReceiverNotFoundException
+     */
     public function testThrowsExceptionWhenNothingMatches()
     {
-        $this->setExpectedException('Bernard\Exception\ReceiverNotFoundException');
-
         $envelope = new Envelope(new PlainMessage('SendNewsletter'));
 
         $this->router->map($envelope);

--- a/tests/Router/SimpleRouterTest.php
+++ b/tests/Router/SimpleRouterTest.php
@@ -6,7 +6,7 @@ use Bernard\Router\SimpleRouter;
 use Bernard\Envelope;
 use Bernard\Message\PlainMessage;
 
-class SimpleRouterTest extends \PHPUnit_Framework_TestCase
+class SimpleRouterTest extends \PHPUnit\Framework\TestCase
 {
     public function setUp()
     {

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
 if [ $TRAVIS_PHP_VERSION != "hhvm" ] && [ $TRAVIS_PHP_VERSION != "7.0" ]; then
-	pyrus install pecl/redis;
-	pyrus build pecl/redis;
-	echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
+	echo "extension=mongo.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
+fi
+
+if [ $TRAVIS_PHP_VERSION != "hhvm" ] && [ $TRAVIS_PHP_VERSION != "5.6" ]; then
+	echo "extension=mongodb.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
 fi
 
 if [ $TRAVIS_PHP_VERSION = "hhvm" ]; then
@@ -12,6 +14,7 @@ if [ $TRAVIS_PHP_VERSION = "hhvm" ]; then
 else
     phpenv config-rm xdebug.ini;
     composer update --no-progress --no-plugins $COMPOSER_OPTS;
+    echo "extension=redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini;
 fi
 
 mysql -e "CREATE DATABASE bernard_test;"


### PR DESCRIPTION
Phpunit 4.x is not supported anymore. So I've upgraded our dependency to ^5.5|^6.0 and used the forward compatibility layer (phpunit 5) for the support of namespaces.

- Upgraded phpunit
- Tweaked travis config to make tests more reliable
- Remove usage of deprecated function of phpunit