### PR TITLE
Fix race condition in FlatFileDriver::popMessage()

### DIFF
--- a/src/Driver/FlatFileDriver.php
+++ b/src/Driver/FlatFileDriver.php
@@ -102,10 +102,9 @@ class FlatFileDriver implements \Bernard\Driver
         while (microtime(true) < $runtime) {
             if ($files) {
                 $id = array_pop($files);
-                $data = array(file_get_contents($queueDir.DIRECTORY_SEPARATOR.$id), $id);
-                rename($queueDir.DIRECTORY_SEPARATOR.$id, $queueDir.DIRECTORY_SEPARATOR.$id.'.proceed');
-
-                return $data;
+                if (@rename($queueDir.DIRECTORY_SEPARATOR.$id, $queueDir.DIRECTORY_SEPARATOR.$id.'.proceed')) {
+                    return array(file_get_contents($queueDir.DIRECTORY_SEPARATOR.$id.'.proceed'), $id);
+                }
             }
 
             usleep(1000);


### PR DESCRIPTION
In race condition situation, `FlatFileDriver` outputs following warnings and returns defective value.

#### Warnings

```
PHP Warning: file_get_contents(/var/folders/r7/mmyml5sj3gzg3zqfy86l9np80000gp/T/000000006fabb4d80000000013831194/task/9.job): failed to open stream: No such file or directory in /Users/akihito1/src/github.com/ackintosh/snidel/vendor/bernard/bernard/src/Driver/FlatFileDriver.php on line 105

....
....

PHP Warning:  rename(/var/folders/r7/mmyml5sj3gzg3zqfy86l9np80000gp/T/000000006fabb4d80000000013831194/task/9.job,/var/folders/r7/mmyml5sj3gzg3zqfy86l9np80000gp/T/000000006fabb4d80000000013831194/task/9.job.proceed): No such file or directory in /Users/akihito1/src/github.com/ackintosh/snidel/vendor/bernard/bernard/src/Driver/FlatFileDriver.php on line 106
```

#### Defective value

`FlatFileDriver::popMessage()` returns defective value.

```
array(2) {
  [0] =>
  bool(false)
  [1] =>
  string(6) "9.job"
}
```

#### Solution

- Rename first.
- Hide warnings that occur when renaming.
  - That means it has consumed by other consumer. It is normal.