### PR TITLE
Extract consumer call_user_func to protected method

### DIFF
--- a/src/Consumer.php
+++ b/src/Consumer.php
@@ -130,8 +130,7 @@ class Consumer
         try {
             $this->dispatcher->dispatch(BernardEvents::INVOKE, new EnvelopeEvent($envelope, $queue));
 
-            // for 5.3 support where a function name is not a callable
-            call_user_func($this->router->map($envelope), $envelope->getMessage());
+            $this->call($envelope);
 
             // We successfully processed the message.
             $queue->acknowledge($envelope);
@@ -142,6 +141,15 @@ class Consumer
         } catch (\Exception $exception) {
             $this->rejectDispatch($exception, $envelope, $queue);
         }
+    }
+
+    /**
+     * @param Envelope $envelope
+     */
+    protected function call(Envelope $envelope)
+    {
+        // for 5.3 support where a function name is not a callable
+        call_user_func($this->router->map($envelope), $envelope->getMessage());
     }
 
     /**


### PR DESCRIPTION
For our usecase we need to do different things depending on the content of the envelope. Right now, this means inheriting and implementing the `invoke` method.

This pull request extracts the `call_user_func` to a protected method so we can inherit this instead, saving us some duplications.