### PR TITLE
Add $duration parameter to PersistentQueue.dequeue()

### DIFF
--- a/src/Queue/PersistentQueue.php
+++ b/src/Queue/PersistentQueue.php
@@ -87,12 +87,14 @@ class PersistentQueue extends AbstractQueue
 
     /**
      * {@inheritdoc}
+     *
+     * @param int $duration Number of seconds to keep polling for messages.
      */
-    public function dequeue()
+    public function dequeue($duration = 5)
     {
         $this->errorIfClosed();
 
-        list($serialized, $receipt) = $this->driver->popMessage($this->name);
+        list($serialized, $receipt) = $this->driver->popMessage($this->name, $duration);
 
         if ($serialized) {
             $envelope = $this->serializer->unserialize($serialized);


### PR DESCRIPTION
To allow some more control over the duration of polling from user land code... Default stays the same: 5 seconds