### PR TITLE
[0.x] DoctrineDriver: Fix "LIMIT 1FOR UPDATE"

### DIFF
--- a/src/Bernard/Driver/DoctrineDriver.php
+++ b/src/Bernard/Driver/DoctrineDriver.php
@@ -103,7 +103,7 @@ class DoctrineDriver implements \Bernard\Driver
     {
         $query = 'SELECT id, message FROM bernard_messages
                   WHERE queue = :queue AND visible = :visible
-                  ORDER BY sentAt, id LIMIT 1' . $this->connection->getDatabasePlatform()->getForUpdateSql();
+                  ORDER BY sentAt, id LIMIT 1 ' . $this->connection->getDatabasePlatform()->getForUpdateSql();
 
         list($id, $message) = $this->connection->fetchArray($query, array(
             'queue' => $queueName,


### PR DESCRIPTION
Using bernardphp with the doctrine driver produces this invalid SELECT statement:
```SQL
SELECT id, message FROM bernard_messages
WHERE queue = :queue AND visible = :visible
ORDER BY sentAt, id 
LIMIT 1FOR UPDATE
```

As you can see there is a space missing between "LIMIT 1" and "FOR UPDATE".

This error exists in 0.12.3 (latest stable) and the 0.x branch. It is fixed in the master though.

This error is thrown and silently ignored in the driver so it never makes it to the consumer. This makes it very hard to notice.