### PR TITLE
Add missing case for SqsClient queue creation

### DIFF
--- a/src/Driver/SqsDriver.php
+++ b/src/Driver/SqsDriver.php
@@ -15,6 +15,7 @@ class SqsDriver extends AbstractPrefetchDriver
 {
     const AWS_SQS_FIFO_SUFFIX = '.fifo';
     const AWS_SQS_EXCEPTION_BAD_REQUEST = 400;
+    const AWS_SQS_EXCEPTION_NOT_FOUND = 404;
 
     protected $sqs;
     protected $queueUrls;
@@ -101,8 +102,10 @@ class SqsDriver extends AbstractPrefetchDriver
             return false;
         } catch (SqsException $exception) {
             if ($previousException = $exception->getPrevious()) {
-                if ($previousException->getCode() === self::AWS_SQS_EXCEPTION_BAD_REQUEST) {
-                    return false;
+                switch ($previousException->getCode()) {
+                    case self::AWS_SQS_EXCEPTION_BAD_REQUEST:
+                    case self::AWS_SQS_EXCEPTION_NOT_FOUND:
+                        return false;
                 }
             }
 


### PR DESCRIPTION
SqsDriver currently handles SQS returning a 400 response if a queue does
not exist when attempting to create it. However, SQS may also return a
404, which SqsDriver does not currently handle.

This commit adds a check for the 404 case so that the queue is also
created in that case.

Here's an example of this issue that I encountered:

```
[Aws\Sqs\Exception\SqsException]
  Error executing "GetQueueUrl" on "http://localstack.harpoon:4576"; AWS HTTP error: Client error: `POST http://localstack.harp
  oon:4576` resulted in a `404 NOT FOUND` response:
  <ErrorResponse xmlns="http://queue.amazonaws.com/doc/2012-11-05/">
      <Error>
          <Type>Sender</Type>
          <Code (truncated...)
   AWS.SimpleQueueService.NonExistentQueue (client): The specified queue does not exist for this wsdl version. - <ErrorResponse
   xmlns="http://queue.amazonaws.com/doc/2012-11-05/">
      <Error>
          <Type>Sender</Type>
          <Code>AWS.SimpleQueueService.NonExistentQueue</Code>
          <Message>The specified queue does not exist for this wsdl version.</Message>
          <Detail/>
      </Error>
      <RequestId>b8bc806b-fa6b-53b5-8be8-cfa2f9836bc3</RequestId>
  </ErrorResponse>

Exception trace:
 () at /src/vendor/aws/aws-sdk-php/src/WrappedHttpHandler.php:192
 Aws\WrappedHttpHandler->parseError() at /src/vendor/aws/aws-sdk-php/src/WrappedHttpHandler.php:101
 Aws\WrappedHttpHandler->Aws\{closure}() at /src/vendor/guzzlehttp/promises/src/Promise.php:203
 GuzzleHttp\Promise\Promise::callHandler() at /src/vendor/guzzlehttp/promises/src/Promise.php:174
 GuzzleHttp\Promise\Promise::GuzzleHttp\Promise\{closure}() at /src/vendor/guzzlehttp/promises/src/RejectedPromise.php:40
 GuzzleHttp\Promise\RejectedPromise::GuzzleHttp\Promise\{closure}() at /src/vendor/guzzlehttp/promises/src/TaskQueue.php:47
 GuzzleHttp\Promise\TaskQueue->run() at /src/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php:96
 GuzzleHttp\Handler\CurlMultiHandler->tick() at /src/vendor/guzzlehttp/guzzle/src/Handler/CurlMultiHandler.php:123
 GuzzleHttp\Handler\CurlMultiHandler->execute() at /src/vendor/guzzlehttp/promises/src/Promise.php:246
 GuzzleHttp\Promise\Promise->invokeWaitFn() at /src/vendor/guzzlehttp/promises/src/Promise.php:223
 GuzzleHttp\Promise\Promise->waitIfPending() at /src/vendor/guzzlehttp/promises/src/Promise.php:267
 GuzzleHttp\Promise\Promise->invokeWaitList() at /src/vendor/guzzlehttp/promises/src/Promise.php:225
 GuzzleHttp\Promise\Promise->waitIfPending() at /src/vendor/guzzlehttp/promises/src/Promise.php:267
 GuzzleHttp\Promise\Promise->invokeWaitList() at /src/vendor/guzzlehttp/promises/src/Promise.php:225
 GuzzleHttp\Promise\Promise->waitIfPending() at /src/vendor/guzzlehttp/promises/src/Promise.php:62
 GuzzleHttp\Promise\Promise->wait() at /src/vendor/aws/aws-sdk-php/src/AwsClientTrait.php:59
 Aws\AwsClient->execute() at /src/vendor/aws/aws-sdk-php/src/AwsClientTrait.php:78
 Aws\AwsClient->__call() at /src/vendor/bernard/bernard/src/Driver/SqsDriver.php:266
 Bernard\Driver\SqsDriver->resolveUrl() at /src/vendor/bernard/bernard/src/Driver/SqsDriver.php:98
 Bernard\Driver\SqsDriver->queueExists() at /src/vendor/bernard/bernard/src/Driver/SqsDriver.php:69
 Bernard\Driver\SqsDriver->createQueue() at /src/vendor/bernard/bernard/src/Queue/PersistentQueue.php:41
 Bernard\Queue\PersistentQueue->register() at /src/vendor/bernard/bernard/src/Queue/PersistentQueue.php:31
 Bernard\Queue\PersistentQueue->__construct() at /src/vendor/bernard/bernard/src/QueueFactory/PersistentFactory.php:41
 Bernard\QueueFactory\PersistentFactory->create() at /src/vendor/bernard/bernard/src/Command/ConsumeCommand.php:75
 Bernard\Command\ConsumeCommand->getQueue() at /src/vendor/bernard/bernard/src/Command/ConsumeCommand.php:53
 Bernard\Command\ConsumeCommand->execute() at /src/vendor/symfony/symfony/src/Symfony/Component/Console/Command/Command.php:264
```

Refs #294, #295, #327 

/cc @holtkamp @acrobat @martinssipenko