### PR TITLE
Move Exception marker interface to the root package

### DIFF
--- a/src/Exception.php
+++ b/src/Exception.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Bernard\Exception;
+namespace Bernard;
 
 /**
  * Interface for exceptions thrown by Bernard.

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -2,6 +2,8 @@
 
 namespace Bernard\Exception;
 
+use Bernard\Exception;
+
 class InvalidArgumentException extends \InvalidArgumentException implements Exception
 {
 }

--- a/src/Exception/InvalidOperationException.php
+++ b/src/Exception/InvalidOperationException.php
@@ -2,6 +2,8 @@
 
 namespace Bernard\Exception;
 
+use Bernard\Exception;
+
 class InvalidOperationException extends \Exception implements Exception
 {
 }

--- a/src/Exception/NotImplementedException.php
+++ b/src/Exception/NotImplementedException.php
@@ -2,6 +2,8 @@
 
 namespace Bernard\Exception;
 
+use Bernard\Exception;
+
 /**
  * Thrown when driver does not support requested feature.
  */

--- a/src/Exception/QueueNotFoundException.php
+++ b/src/Exception/QueueNotFoundException.php
@@ -2,6 +2,8 @@
 
 namespace Bernard\Exception;
 
+use Bernard\Exception;
+
 /**
  * Thrown when queue does not exist.
  */

--- a/src/Exception/ReceiverNotFoundException.php
+++ b/src/Exception/ReceiverNotFoundException.php
@@ -2,6 +2,8 @@
 
 namespace Bernard\Exception;
 
+use Bernard\Exception;
+
 /**
  * Is thrown when a Router tries to map a Envelope to a receiver and
  * cannot be done.

--- a/src/Exception/ServiceUnavailableException.php
+++ b/src/Exception/ServiceUnavailableException.php
@@ -2,6 +2,8 @@
 
 namespace Bernard\Exception;
 
+use Bernard\Exception;
+
 /**
  * Thrown when driver implementation is unavailable.
  */

--- a/tests/Exception/ExceptionTest.php
+++ b/tests/Exception/ExceptionTest.php
@@ -2,6 +2,8 @@
 
 namespace Bernard\Tests\Exception;
 
+use Bernard\Exception;
+
 class ExceptionTest extends \PHPUnit\Framework\TestCase
 {
     /**
@@ -11,13 +13,14 @@ class ExceptionTest extends \PHPUnit\Framework\TestCase
     {
         try {
             throw new $exception();
-        } catch (\Exception $e) {
-            $this->assertInstanceOf('\Bernard\Exception\Exception', $e);
+        } catch (Exception $e) {
+            $this->assertInstanceOf(Exception::class, $e);
             $this->assertInstanceOf($exception, $e);
             $this->assertInstanceOf($base, $e);
 
             return;
         }
+
         $this->fail('Exception not caught');
     }
 


### PR DESCRIPTION
This is the pattern that we followed with other interfaces.

Fixes #367