### PR TITLE
Add missing case for SqsClient queue creation

### DIFF
--- a/src/Driver/Sqs/Driver.php
+++ b/src/Driver/Sqs/Driver.php
@@ -15,6 +15,7 @@ final class Driver extends AbstractPrefetchDriver
 {
     const AWS_SQS_FIFO_SUFFIX = '.fifo';
     const AWS_SQS_EXCEPTION_BAD_REQUEST = 400;
+    const AWS_SQS_EXCEPTION_NOT_FOUND = 404;
 
     private $sqs;
     private $queueUrls;
@@ -100,8 +101,10 @@ final class Driver extends AbstractPrefetchDriver
             return false;
         } catch (SqsException $exception) {
             if ($previousException = $exception->getPrevious()) {
-                if ($previousException->getCode() === self::AWS_SQS_EXCEPTION_BAD_REQUEST) {
-                    return false;
+                switch ($previousException->getCode()) {
+                    case self::AWS_SQS_EXCEPTION_BAD_REQUEST:
+                    case self::AWS_SQS_EXCEPTION_NOT_FOUND:
+                        return false;
                 }
             }
 


### PR DESCRIPTION
Fixes #350 (resubmission)

SqsDriver currently handles SQS returning a 400 response if a queue does
not exist when attempting to create it. However, SQS may also return a
404, which SqsDriver does not currently handle.

This commit adds a check for the 404 case so that the queue is also
created in that case.

Refs #294, #295, #327