### PR TITLE
Use dedicated PHPUnit assertions

### DIFF
--- a/tests/Driver/Doctrine/AbstractDriverTest.php
+++ b/tests/Driver/Doctrine/AbstractDriverTest.php
@@ -55,7 +55,7 @@ abstract class AbstractDriverTest extends \PHPUnit\Framework\TestCase
 
         $this->driver->popMessage('non-existent-queue', 0.001);
 
-        $this->assertTrue((microtime(true) - $microtime) >= 0.001);
+        $this->assertGreaterThanOrEqual(0.001, microtime(true) - $microtime);
     }
 
     public function testCreateAndRemoveQueue()

--- a/tests/Driver/FlatFile/DriverTest.php
+++ b/tests/Driver/FlatFile/DriverTest.php
@@ -39,7 +39,7 @@ class DriverTest extends \PHPUnit\Framework\TestCase
         $this->driver->createQueue('send-newsletter');
         $this->driver->createQueue('send-newsletter');
 
-        $this->assertTrue(is_dir($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter'));
+        $this->assertDirectoryExists($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter');
     }
 
     public function testRemove()
@@ -49,7 +49,7 @@ class DriverTest extends \PHPUnit\Framework\TestCase
 
         $this->driver->removeQueue('send-newsletter');
 
-        $this->assertFalse(is_dir($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter'));
+        $this->assertDirectoryNotExists($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter');
     }
 
     public function testRemoveQueueWithPoppedMessage()
@@ -60,7 +60,7 @@ class DriverTest extends \PHPUnit\Framework\TestCase
 
         $this->driver->removeQueue('send-newsletter');
 
-        $this->assertFalse(is_dir($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter'));
+        $this->assertDirectoryNotExists($this->baseDir.\DIRECTORY_SEPARATOR.'send-newsletter');
     }
 
     public function testPushMessage()

--- a/tests/Message/PlainMessageTest.php
+++ b/tests/Message/PlainMessageTest.php
@@ -17,7 +17,7 @@ final class PlainMessageTest extends \PHPUnit\Framework\TestCase
             'key3' => null,
         ]);
 
-        $this->assertTrue(isset($message['key1']));
+        $this->assertArrayHasKey('key1', $message);
 
         $this->assertEquals(1, $message['key1']);
         $this->assertEquals([1, 2, 3, 4], $message['key2']);


### PR DESCRIPTION
Using PHPUnit dedicated assertions will give us better error messages, making easier to debug fails. For example:
```diff
-$this->assertTrue(in_array('foo', ['bar', 'baz']));
+$this->assertContains('foo', ['baz', 'bar']);
```

Will give us:
```diff
-Failed asserting that false is true.
+Failed asserting that an array contains 'foo'.
```