### PR TITLE
Fix doctrine peek

### DIFF
--- a/src/Driver/DoctrineDriver.php
+++ b/src/Driver/DoctrineDriver.php
@@ -114,10 +114,10 @@ class DoctrineDriver implements \Bernard\Driver
      */
     public function peekQueue($queueName, $index = 0, $limit = 20)
     {
-        $parameters = [$queueName, $limit, $index];
-        $types = ['string', 'integer', 'integer'];
+        $parameters = [$queueName, true, $limit, $index];
+        $types = ['string', 'boolean', 'integer', 'integer'];
 
-        $query = 'SELECT message FROM bernard_messages WHERE queue = ? ORDER BY sentAt LIMIT ? OFFSET ?';
+        $query = 'SELECT message FROM bernard_messages WHERE queue = ? AND visible = ? ORDER BY sentAt LIMIT ? OFFSET ?';
 
         return $this
             ->connection

--- a/tests/Driver/AbstractDoctrineDriverTest.php
+++ b/tests/Driver/AbstractDoctrineDriverTest.php
@@ -133,6 +133,21 @@ abstract class AbstractDoctrineDriverTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(1, $this->driver->countMessages('send-newsletter'));
     }
 
+    public function testPeekMessagesExcludesPoppedMessages()
+    {
+        $this->driver->pushMessage('send-newsletter', 'my-message-1');
+        $this->driver->pushMessage('send-newsletter', 'my-message-2');
+        $this->driver->pushMessage('send-newsletter', 'my-message-3');
+
+        $this->assertCount(3, $this->driver->peekQueue('send-newsletter'));
+        $this->assertEquals(3, $this->driver->countMessages('send-newsletter'));
+
+        $this->driver->popMessage('send-newsletter');
+
+        $this->assertCount(2, $this->driver->peekQueue('send-newsletter'));
+        $this->assertEquals(2, $this->driver->countMessages('send-newsletter'));
+    }
+
     public function testListQueues()
     {
         $this->driver->pushMessage('import', 'message1');


### PR DESCRIPTION
I think DoctrineDriver's implementation of peek should include only visible messages.