### PR TITLE
Added support for the mongodb-php-library/extension combo

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "php": "^5.6 || ^7.0",
         "beberlei/assert": "^2.1",
         "bernard/normalt": "^1.0",
-        "mongodb/mongodb": "~1.1",
+        "mongodb/mongodb": "^1.3",
         "symfony/event-dispatcher": "^3.0 || ^4.0"
     },
     "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,6 @@
         "php": "^5.6 || ^7.0",
         "beberlei/assert": "^2.1",
         "bernard/normalt": "^1.0",
-        "mongodb/mongodb": "^1.3",
         "symfony/event-dispatcher": "^3.0 || ^4.0"
     },
     "require-dev" : {

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "type": "library",
     "require": {
         "php": "^5.6 || ^7.0",
-        "beberlei/assert": "^2.1",
+        "beberlei/assert": "^3.2",
         "bernard/normalt": "^1.0",
         "symfony/event-dispatcher": "^3.0 || ^4.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,7 @@
         "php": "^5.6 || ^7.0",
         "beberlei/assert": "^2.1",
         "bernard/normalt": "^1.0",
+        "mongodb/mongodb": "~1.1",
         "symfony/event-dispatcher": "^3.0 || ^4.0"
     },
     "require-dev" : {

--- a/src/Driver/NewMongoDB/Driver.php
+++ b/src/Driver/NewMongoDB/Driver.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Bernard\Driver\NewMongoDB;
+
+//use MongoCollection;
+//use MongoDate;
+//use MongoId;
+
+use MongoDB\Collection;
+
+/**
+ * Driver supporting MongoDB.
+ */
+final class Driver implements \Bernard\Driver
+{
+    private $messages;
+    private $queues;
+
+    /**
+     * @param MongoCollection $queues   Collection where queues will be stored
+     * @param MongoCollection $messages Collection where messages will be stored
+     */
+    public function __construct(Collection $queues, Collection $messages)
+    {
+        $this->queues = $queues;
+        $this->messages = $messages;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function listQueues()
+    {
+        return $this->queues->distinct('_id');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function createQueue($queueName)
+    {
+        $data = ['_id' => (string) $queueName];
+
+        $this->queues->update($data, $data, ['upsert' => true]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function countMessages($queueName)
+    {
+        return $this->messages->count([
+            'queue' => (string) $queueName,
+            'visible' => true,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function pushMessage($queueName, $message)
+    {
+        $data = [
+            'queue' => (string) $queueName,
+            'message' => (string) $message,
+            'sentAt' => new MongoDate(),
+            'visible' => true,
+        ];
+
+        $this->messages->insert($data);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function popMessage($queueName, $duration = 5)
+    {
+        $runtime = microtime(true) + $duration;
+
+        while (microtime(true) < $runtime) {
+            $result = $this->messages->findAndModify(
+                ['queue' => (string) $queueName, 'visible' => true],
+                ['$set' => ['visible' => false]],
+                ['message' => 1],
+                ['sort' => ['sentAt' => 1]]
+            );
+
+            if ($result) {
+                return [(string) $result['message'], (string) $result['_id']];
+            }
+
+            usleep(10000);
+        }
+
+        return [null, null];
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function acknowledgeMessage($queueName, $receipt)
+    {
+        $this->messages->remove([
+            '_id' => new MongoId((string) $receipt),
+            'queue' => (string) $queueName,
+        ]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function peekQueue($queueName, $index = 0, $limit = 20)
+    {
+        $query = ['queue' => (string) $queueName, 'visible' => true];
+        $fields = ['_id' => 0, 'message' => 1];
+
+        $cursor = $this->messages
+            ->find($query, $fields)
+            ->sort(['sentAt' => 1])
+            ->limit($limit)
+            ->skip($index)
+        ;
+
+        $mapper = function ($result) {
+            return (string) $result['message'];
+        };
+
+        return array_map($mapper, iterator_to_array($cursor, false));
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function removeQueue($queueName)
+    {
+        $this->queues->remove(['_id' => $queueName]);
+        $this->messages->remove(['queue' => (string) $queueName]);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function info()
+    {
+        return [
+            'messages' => (string) $this->messages,
+            'queues' => (string) $this->queues,
+        ];
+    }
+}

--- a/tests/Driver/NewMongoDB/CursorStub.php
+++ b/tests/Driver/NewMongoDB/CursorStub.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Bernard\Tests\Driver\NewMongoDB;
+
+use ArrayIterator;
+
+
+class CursorStub
+{
+    public function toArray(){
+        return [
+            ['message' => 'message1'],
+            ['message' => 'message2'],
+        ];
+    }
+}

--- a/tests/Driver/NewMongoDB/DriverFunctionalTest.php
+++ b/tests/Driver/NewMongoDB/DriverFunctionalTest.php
@@ -3,9 +3,6 @@
 namespace Bernard\Tests\Driver\NewMongoDB;
 
 use Bernard\Driver\NewMongoDB\Driver;
-//use MongoClient;
-//use MongoCollection;
-//use MongoConnectionException;
 use MongoDB\Client;
 
 /**
@@ -127,6 +124,8 @@ class DriverFunctionalTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(1, $queues);
         $this->assertNotContains('foo', $queues);
         $this->assertContains('bar', $queues);
+
+        $this->driver->removeQueue('bar');
     }
 
     public function testRemoveQueueDeletesMessages()

--- a/tests/Driver/NewMongoDB/DriverFunctionalTest.php
+++ b/tests/Driver/NewMongoDB/DriverFunctionalTest.php
@@ -1,0 +1,161 @@
+<?php
+
+namespace Bernard\Tests\Driver\NewMongoDB;
+
+use Bernard\Driver\NewMongoDB\Driver;
+//use MongoClient;
+//use MongoCollection;
+//use MongoConnectionException;
+use MongoDB\Client;
+
+/**
+ * @coversDefaultClass \Bernard\Driver\MongoDB\Driver
+ * @group functional
+ */
+class DriverFunctionalTest extends \PHPUnit\Framework\TestCase
+{
+    const DATABASE = 'bernardQueueTest';
+    const MESSAGES = 'bernardMessages';
+    const QUEUES = 'bernardQueues';
+
+    /** @var MongoCollection */
+    private $messages;
+
+    /** @var MongoCollection */
+    private $queues;
+
+    /** @var Driver */
+    private $driver;
+
+    public function setUp()
+    {
+        if (!class_exists('MongoDB\Driver\Manager')) {
+            $this->markTestSkipped('New MongoDB extension is not available.');
+        }
+
+        try {
+            $mongoClient = new Client();
+        } catch (MongoConnectionException $e) {
+            $this->markTestSkipped('Cannot connect to New MongoDB server.');
+        }
+
+        $this->queues = $mongoClient->selectCollection(self::DATABASE, self::QUEUES);
+        $this->messages = $mongoClient->selectCollection(self::DATABASE, self::MESSAGES);
+        $this->driver = new Driver($this->queues, $this->messages);
+    }
+
+    public function tearDown()
+    {
+        if (!$this->messages instanceof MongoCollection) {
+            return;
+        }
+
+        $this->messages->drop();
+        $this->queues->drop();
+    }
+
+    /**
+     * @medium
+     * @covers ::acknowledgeMessage()
+     * @covers ::countMessages()
+     * @covers ::popMessage()
+     * @covers ::pushMessage()
+     */
+    public function testMessageLifecycle()
+    {
+        $this->assertEquals(0, $this->driver->countMessages('foo'));
+
+        $this->driver->pushMessage('foo', 'message1');
+        $this->assertEquals(1, $this->driver->countMessages('foo'));
+
+        $this->driver->pushMessage('foo', 'message2');
+        $this->assertEquals(2, $this->driver->countMessages('foo'));
+
+        list($message1, $receipt1) = $this->driver->popMessage('foo');
+        $this->assertSame('message1', $message1, 'The first message pushed is popped first');
+        $this->assertRegExp('/^[a-f\d]{24}$/i', $receipt1, 'The message receipt is an ObjectId');
+        $this->assertEquals(1, $this->driver->countMessages('foo'));
+
+        list($message2, $receipt2) = $this->driver->popMessage('foo');
+        $this->assertSame('message2', $message2, 'The second message pushed is popped second');
+        $this->assertRegExp('/^[a-f\d]{24}$/i', $receipt2, 'The message receipt is an ObjectId');
+        $this->assertEquals(0, $this->driver->countMessages('foo'));
+
+        list($message3, $receipt3) = $this->driver->popMessage('foo', 1);
+        $this->assertNull($message3, 'Null message is returned when popping an empty queue');
+        $this->assertNull($receipt3, 'Null receipt is returned when popping an empty queue');
+
+        $this->assertEquals(2, $this->messages->count(), 'Popped messages remain in the database');
+
+        $this->driver->acknowledgeMessage('foo', $receipt1);
+        $this->assertEquals(1, $this->messages->count(), 'Acknowledged messages are removed from the database');
+
+        $this->driver->acknowledgeMessage('foo', $receipt2);
+        $this->assertEquals(0, $this->messages->count(), 'Acknowledged messages are removed from the database');
+    }
+
+    public function testPeekQueue()
+    {
+        $this->driver->pushMessage('foo', 'message1');
+        $this->driver->pushMessage('foo', 'message2');
+
+        $this->assertSame(['message1', 'message2'], $this->driver->peekQueue('foo'));
+        $this->assertSame(['message2'], $this->driver->peekQueue('foo', 1));
+        $this->assertSame([], $this->driver->peekQueue('foo', 2));
+        $this->assertSame(['message1'], $this->driver->peekQueue('foo', 0, 1));
+        $this->assertSame(['message2'], $this->driver->peekQueue('foo', 1, 1));
+    }
+
+    /**
+     * @covers ::createQueue()
+     * @covers ::listQueues()
+     * @covers ::removeQueue()
+     */
+    public function testQueueLifecycle()
+    {
+        $this->driver->createQueue('foo');
+        $this->driver->createQueue('bar');
+
+        $queues = $this->driver->listQueues();
+        $this->assertCount(2, $queues);
+        $this->assertContains('foo', $queues);
+        $this->assertContains('bar', $queues);
+
+        $this->driver->removeQueue('foo');
+
+        $queues = $this->driver->listQueues();
+        $this->assertCount(1, $queues);
+        $this->assertNotContains('foo', $queues);
+        $this->assertContains('bar', $queues);
+    }
+
+    public function testRemoveQueueDeletesMessages()
+    {
+        $this->driver->pushMessage('foo', 'message1');
+        $this->driver->pushMessage('foo', 'message2');
+        $this->assertEquals(2, $this->driver->countMessages('foo'));
+        $this->assertEquals(2, $this->messages->count());
+
+        $this->driver->removeQueue('foo');
+        $this->assertEquals(0, $this->driver->countMessages('foo'));
+        $this->assertEquals(0, $this->messages->count());
+    }
+
+    public function testCreateQueueWithDuplicateNameIsNoop()
+    {
+        $this->driver->createQueue('foo');
+        $this->driver->createQueue('foo');
+
+        $this->assertSame(['foo'], $this->driver->listQueues());
+    }
+
+    public function testInfo()
+    {
+        $info = [
+            'messages' => self::DATABASE.'.'.self::MESSAGES,
+            'queues' => self::DATABASE.'.'.self::QUEUES,
+        ];
+
+        $this->assertSame($info, $this->driver->info());
+    }
+}

--- a/tests/Driver/NewMongoDB/DriverTest.php
+++ b/tests/Driver/NewMongoDB/DriverTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Bernard\Tests\Driver\NewMongoDB;
+
+use Bernard\Driver\MongoDB\Driver;
+use ArrayIterator;
+use MongoDate;
+use MongoId;
+
+class DriverTest extends \PHPUnit\Framework\TestCase
+{
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    private $messages;
+
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    private $queues;
+
+    /** @var Driver */
+    private $driver;
+
+    public function setUp()
+    {
+        if (!class_exists('MongoCollection')) {
+            $this->markTestSkipped('MongoDB extension is not available.');
+        }
+
+        $this->queues = $this->getMockMongoCollection();
+        $this->messages = $this->getMockMongoCollection();
+        $this->driver = new Driver($this->queues, $this->messages);
+    }
+
+    public function testListQueues()
+    {
+        $this->queues->expects($this->once())
+            ->method('distinct')
+            ->with('_id')
+            ->will($this->returnValue(['foo', 'bar']));
+
+        $this->assertSame(['foo', 'bar'], $this->driver->listQueues());
+    }
+
+    public function testCreateQueue()
+    {
+        $this->queues->expects($this->once())
+            ->method('update')
+            ->with(['_id' => 'foo'], ['_id' => 'foo'], ['upsert' => true]);
+
+        $this->driver->createQueue('foo');
+    }
+
+    public function testCountMessages()
+    {
+        $this->messages->expects($this->once())
+            ->method('count')
+            ->with(['queue' => 'foo', 'visible' => true])
+            ->will($this->returnValue(2));
+
+        $this->assertSame(2, $this->driver->countMessages('foo'));
+    }
+
+    public function testPushMessage()
+    {
+        $this->messages->expects($this->once())
+            ->method('insert')
+            ->with($this->callback(function ($data) {
+                return $data['queue'] === 'foo' &&
+                       $data['message'] === 'message1' &&
+                       $data['sentAt'] instanceof MongoDate &&
+                       $data['visible'] === true;
+            }));
+
+        $this->driver->pushMessage('foo', 'message1');
+    }
+
+    public function testPopMessageWithFoundMessage()
+    {
+        $this->messages->expects($this->atLeastOnce())
+            ->method('findAndModify')
+            ->with(
+                ['queue' => 'foo', 'visible' => true],
+                ['$set' => ['visible' => false]],
+                ['message' => 1],
+                ['sort' => ['sentAt' => 1]]
+            )
+            ->will($this->returnValue(['message' => 'message1', '_id' => '000000000000000000000000']));
+
+        list($message, $receipt) = $this->driver->popMessage('foo');
+        $this->assertSame('message1', $message);
+        $this->assertSame('000000000000000000000000', $receipt);
+    }
+
+    /**
+     * @medium
+     */
+    public function testPopMessageWithMissingMessage()
+    {
+        $this->messages->expects($this->atLeastOnce())
+            ->method('findAndModify')
+            ->with(
+                ['queue' => 'foo', 'visible' => true],
+                ['$set' => ['visible' => false]],
+                ['message' => 1],
+                ['sort' => ['sentAt' => 1]]
+            )
+            ->will($this->returnValue(false));
+
+        list($message, $receipt) = $this->driver->popMessage('foo', 1);
+        $this->assertNull($message);
+        $this->assertNull($receipt);
+    }
+
+    public function testAcknowledgeMessage()
+    {
+        $this->messages->expects($this->once())
+            ->method('remove')
+            ->with($this->callback(function ($query) {
+                return $query['_id'] instanceof MongoId &&
+                       (string) $query['_id'] === '000000000000000000000000' &&
+                       $query['queue'] === 'foo';
+            }));
+
+        $this->driver->acknowledgeMessage('foo', '000000000000000000000000');
+    }
+
+    public function testPeekQueue()
+    {
+        $cursor = $this->getMockBuilder('MongoCursor')
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->messages->expects($this->once())
+            ->method('find')
+            ->with(['queue' => 'foo', 'visible' => true], ['_id' => 0, 'message' => 1])
+            ->will($this->returnValue($cursor));
+
+        $cursor->expects($this->at(0))
+            ->method('sort')
+            ->with(['sentAt' => 1])
+            ->will($this->returnValue($cursor));
+
+        $cursor->expects($this->at(1))
+            ->method('limit')
+            ->with(20)
+            ->will($this->returnValue($cursor));
+
+        /* Rather than mock MongoCursor's iterator interface, take advantage of
+         * the final fluent method call and return an ArrayIterator. */
+        $cursor->expects($this->at(2))
+            ->method('skip')
+            ->with(0)
+            ->will($this->returnValue(new ArrayIterator([
+                ['message' => 'message1'],
+                ['message' => 'message2'],
+            ])));
+
+        $this->assertSame(['message1', 'message2'], $this->driver->peekQueue('foo'));
+    }
+
+    public function testRemoveQueue()
+    {
+        $this->queues->expects($this->once())
+            ->method('remove')
+            ->with(['_id' => 'foo']);
+
+        $this->messages->expects($this->once())
+            ->method('remove')
+            ->with(['queue' => 'foo']);
+
+        $this->driver->removeQueue('foo');
+    }
+
+    public function testInfo()
+    {
+        $this->queues->expects($this->once())
+            ->method('__toString')
+            ->will($this->returnValue('db.queues'));
+
+        $this->messages->expects($this->once())
+            ->method('__toString')
+            ->will($this->returnValue('db.messages'));
+
+        $info = [
+            'messages' => 'db.messages',
+            'queues' => 'db.queues',
+        ];
+
+        $this->assertSame($info, $this->driver->info());
+    }
+
+    private function getMockMongoCollection()
+    {
+        return $this->getMockBuilder('MongoCollection')
+            ->disableOriginalConstructor()
+            ->getMock();
+    }
+}


### PR DESCRIPTION
The ext-mongo has been replaced by the mongodb-php-library/extension driver - this PR adds support for it.