### PR TITLE
fix performance issue, round robined (persistent) queues should not wait

### DIFF
--- a/src/Driver/Amqp/Driver.php
+++ b/src/Driver/Amqp/Driver.php
@@ -99,20 +99,21 @@ final class Driver implements \Bernard\Driver
      */
     public function popMessage($queueName, $duration = 5)
     {
-        $runtime = microtime(true) + $duration;
+        $startAt = microtime(true);
 
-        while (microtime(true) < $runtime) {
+        while (true) {
             $message = $this->getChannel()->basic_get($queueName);
 
             if ($message) {
                 return [$message->body, $message->get('delivery_tag')];
             }
 
-            // sleep for 10 ms to prevent hammering CPU
             usleep(10000);
-        }
 
-        return [null, null];
+            if ((microtime(true) - $startAt) >= $duration) {
+                return [null, null];
+            }
+        }
     }
 
     /**

--- a/src/Driver/Doctrine/Driver.php
+++ b/src/Driver/Doctrine/Driver.php
@@ -77,9 +77,9 @@ final class Driver implements \Bernard\Driver
      */
     public function popMessage($queueName, $duration = 5)
     {
-        $runtime = microtime(true) + $duration;
+        $startAt = microtime(true);
 
-        while (microtime(true) < $runtime) {
+        while (true) {
             $this->connection->beginTransaction();
 
             try {
@@ -94,8 +94,11 @@ final class Driver implements \Bernard\Driver
                 return $message;
             }
 
-            //sleep for 10 ms
             usleep(10000);
+
+            if ((microtime(true) - $startAt) >= $duration) {
+                return;
+            }
         }
     }
 

--- a/src/Driver/MongoDB/Driver.php
+++ b/src/Driver/MongoDB/Driver.php
@@ -73,9 +73,9 @@ final class Driver implements \Bernard\Driver
      */
     public function popMessage($queueName, $duration = 5)
     {
-        $runtime = microtime(true) + $duration;
+        $startAt = microtime(true);
 
-        while (microtime(true) < $runtime) {
+        while (true) {
             $result = $this->messages->findAndModify(
                 ['queue' => (string) $queueName, 'visible' => true],
                 ['$set' => ['visible' => false]],
@@ -88,9 +88,11 @@ final class Driver implements \Bernard\Driver
             }
 
             usleep(10000);
-        }
 
-        return [null, null];
+            if ((microtime(true) - $startAt) >= $duration) {
+                return array(null, null);
+            }
+        }
     }
 
     /**

--- a/src/Queue/RoundRobinQueue.php
+++ b/src/Queue/RoundRobinQueue.php
@@ -54,7 +54,7 @@ class RoundRobinQueue implements Queue
 
         while (count($checked) < count($this->queues)) {
             $queue = current($this->queues);
-            $envelope = $queue->dequeue();
+            $envelope = $queue->dequeue(0);
             if (false === next($this->queues)) {
                 reset($this->queues);
             }
@@ -64,6 +64,9 @@ class RoundRobinQueue implements Queue
             } else {
                 $checked[] = $queue;
             }
+
+            //sleep for 10 ms
+            usleep(10000);
         }
 
         return $envelope;


### PR DESCRIPTION
This fixes a performance issue where by persistent queues, with drivers that respect `$duration` on popMessage.

This issue is that, during a round robin, an empty persistent queue will wait for 5 seconds before allowing the next queue to dequeue. The problem is obviously compounded the more queues in the round robin.