### PR TITLE
[PHP 7.3 Critical bug] PCRE2 fix

### DIFF
--- a/src/Bernard/Message/DefaultMessage.php
+++ b/src/Bernard/Message/DefaultMessage.php
@@ -19,7 +19,7 @@ class DefaultMessage extends AbstractMessage
             $this->$k = $v;
         }
 
-        $this->name = preg_replace('/(^([0-9]+))|([^[:alnum:]-_+])/i', '', $name);
+        $this->name = preg_replace('/(^([0-9]+))|([^[:alnum:]\-_+])/i', '', $name);
     }
 
     /**


### PR DESCRIPTION
PHP 7.3 will not throw a warning `Warning: preg_match(): Compilation failed: invalid range in character class at offset ...`

The problem is with the pattern: PCRE2 is strict that the hyphen needs to be moved to the end, or escaped for this to work.

Ref: https://ayesh.me/Upgrade-PHP-7.3#pcre2