### PR TITLE
fix: php 8.1 Countable::count incompatibilities

### DIFF
--- a/src/Queue/RoundRobinQueue.php
+++ b/src/Queue/RoundRobinQueue.php
@@ -148,6 +148,7 @@ class RoundRobinQueue implements Queue
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return array_sum(array_map('count', $this->queues));

--- a/src/QueueFactory/InMemoryFactory.php
+++ b/src/QueueFactory/InMemoryFactory.php
@@ -35,6 +35,7 @@ class InMemoryFactory implements \Bernard\QueueFactory
     /**
      * {@inheritdoc}
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->queues);

--- a/src/QueueFactory/PersistentFactory.php
+++ b/src/QueueFactory/PersistentFactory.php
@@ -63,6 +63,7 @@ class PersistentFactory implements \Bernard\QueueFactory
     /**
      * @return int
      */
+    #[\ReturnTypeWillChange]
     public function count()
     {
         return count($this->driver->listQueues());


### PR DESCRIPTION
Fixes incompatibilities with php 8.1 Countable::count interface changes keeping the compatibility with older PHP versions.