### PR TITLE
Drop PHP 7 support

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '7.4'
+          php-version: '8.0'
           coverage: none
           extensions: mbstring, intl
           tools: composer:v2
@@ -38,7 +38,7 @@ jobs:
     strategy:
       max-parallel: 10
       matrix:
-        php: ['7.4', '8.0']
+        php: ['8.0', '8.1']
 
     steps:
       - name: Set up PHP

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "homepage": "https://github.com/bernardphp/bernard",
     "type": "library",
     "require": {
-        "php": ">=7.4",
+        "php": ">=8.0",
         "beberlei/assert": "^2.1 || ^3.0",
         "bernard/normalt": "^1.0",
         "symfony/event-dispatcher": "^3.0 || ^4.0"

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,12 @@
     "name": "bernard/bernard",
     "description": "Message queue abstraction layer",
     "license": "MIT",
-    "keywords": ["message queue", "message", "queue", "bernard"],
+    "keywords": [
+        "message queue",
+        "message",
+        "queue",
+        "bernard"
+    ],
     "homepage": "https://github.com/bernardphp/bernard",
     "type": "library",
     "require": {
@@ -11,7 +16,7 @@
         "bernard/normalt": "^1.0",
         "symfony/event-dispatcher": "^3.0 || ^4.0"
     },
-    "require-dev" : {
+    "require-dev": {
         "doctrine/dbal": "^2.5",
         "doctrine/instantiator": "^1.0.5",
         "friends-of-phpspec/phpspec-code-coverage": "^6.0",
@@ -25,13 +30,15 @@
         "doctrine/dbal": "Allow sending messages to simulated message queue in a database via doctrine dbal",
         "mongodb/mongodb": "Allow sending messages to a MongoDB server via PHP Driver"
     },
-    "autoload" : {
-        "psr-4" : { "Bernard\\" : "src/" }
+    "autoload": {
+        "psr-4": {
+            "Bernard\\": "src/"
+        }
     },
-    "autoload-dev" : {
-        "psr-4" : {
-            "Bernard\\Tests\\" : "tests/",
-            "spec\\Bernard\\" : "spec/"
+    "autoload-dev": {
+        "psr-4": {
+            "Bernard\\Tests\\": "tests/",
+            "spec\\Bernard\\": "spec/"
         }
     },
     "config": {
@@ -49,9 +56,9 @@
         ],
         "test-functional": "php vendor/bin/phpunit -v --group functional"
     },
-    "extra" : {
-        "branch-alias" : {
-            "dev-master" : "2.0.x-dev"
+    "extra": {
+        "branch-alias": {
+            "dev-master": "2.0.x-dev"
         }
     },
     "prefer-stable": true,


### PR DESCRIPTION
PHP 7 support ends this year.

Furthermore, we plan to use the `mixed` pseudo type hint.